### PR TITLE
[FEAT] 회원가입 화면 구현 (TICO-32)

### DIFF
--- a/Mobile/PomoroDo/app/build.gradle
+++ b/Mobile/PomoroDo/app/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 
     // material3 최신 버전 적용을 위한 라이브러리
     implementation libs.bundles.material3
+
+    // url 을 사용한 이미지 로딩을 위한 라이브러리
+    implementation libs.glide.compose
 }
 
 // Allow references to generated code

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -4,11 +4,14 @@ import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -54,12 +57,21 @@ import com.tico.pomorodo.ui.theme.laundryGothic
 @Composable
 fun SignUpScreen() {
     Column(
-        modifier = Modifier.padding(horizontal = 30.dp),
+        modifier = Modifier.padding(horizontal = 30.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Text(
+            text = "회원 정보 입력",
+            color = PomoroDoTheme.colorScheme.onBackground,
+            style = PomoroDoTheme.typography.laundryGothicBold20
+        )
+        Spacer(modifier = Modifier.height(20.dp))
         IconDefaultProfile()
+        Spacer(modifier = Modifier.height(18.dp))
         ProfileEditText()
-        SubmitButton(true)
+        Spacer(modifier = Modifier.height(20.dp))
+        SubmitButton()
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -17,10 +17,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,7 +40,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
@@ -58,10 +59,10 @@ fun SignUpScreen() {
     ) {
         IconDefaultProfile()
         ProfileEditText()
+        SubmitButton(true)
     }
 }
 
-@Preview
 @Composable
 fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
     Box(modifier = Modifier
@@ -101,7 +102,6 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Preview
 @Composable
 fun ProfileEditText() {
     var text by rememberSaveable { mutableStateOf("") }
@@ -147,5 +147,26 @@ fun ProfileEditText() {
             ),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 14.dp)
         )
+    }
+}
+
+@Composable
+fun SubmitButton(enable: Boolean = false) {
+    TextButton(
+        onClick = { /*TODO*/ },
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 0.dp),
+        enabled = enable,
+        shape = RoundedCornerShape(10.dp),
+        colors = ButtonColors(
+            containerColor = PomoroDoTheme.colorScheme.primaryContainer,
+            contentColor = PomoroDoTheme.colorScheme.background,
+            disabledContainerColor = PomoroDoTheme.colorScheme.gray70,
+            disabledContentColor = PomoroDoTheme.colorScheme.background
+        ),
+        contentPadding = PaddingValues(vertical = 12.dp)
+    ) {
+        Text(text = "가입", style = PomoroDoTheme.typography.laundryGothicRegular18)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -1,0 +1,79 @@
+package com.tico.pomorodo.ui.auth.view
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.request.RequestOptions
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.glide.GlideImage
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.iconpack.IcProfileDefault
+import com.tico.pomorodo.ui.theme.IconPack
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun SignUpScreen() {
+
+}
+
+@Preview
+@Composable
+fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
+    Box(modifier = Modifier
+        .size(110.dp)
+        .clip(shape = CircleShape)
+        .clickable { /*TODO*/ }) {
+        if (defaultProfileUri == null) {
+            Icon(
+                imageVector = IconPack.IcProfileDefault,
+                contentDescription = stringResource(R.string.content_ic_profile_default),
+                tint = Color.Unspecified
+            )
+        } else {
+            GlideImage(
+                imageModel = { defaultProfileUri },
+                requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.AUTOMATIC) },
+                imageOptions = ImageOptions(
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center
+                )
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = Color(0x80000000)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.content_profile_change),
+                color = MaterialTheme.colorScheme.background,
+                style = PomoroDoTheme.typography.laundryGothicRegular26
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ProfileEditTextBox() {
+
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -4,19 +4,35 @@ import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -27,10 +43,17 @@ import com.tico.pomorodo.R
 import com.tico.pomorodo.ui.iconpack.IcProfileDefault
 import com.tico.pomorodo.ui.theme.IconPack
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
+import com.tico.pomorodo.ui.theme.laundryGothic
 
 @Composable
 fun SignUpScreen() {
-
+    Column(
+        modifier = Modifier.padding(horizontal = 30.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        IconDefaultProfile()
+        ProfileEditText()
+    }
 }
 
 @Preview
@@ -60,7 +83,7 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = Color(0x80000000)),
+                .background(color = PomoroDoTheme.colorScheme.trim),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -74,6 +97,38 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
 
 @Preview
 @Composable
-fun ProfileEditTextBox() {
+fun ProfileEditText() {
+    val focusManager = LocalFocusManager.current
+    var text by rememberSaveable { mutableStateOf("") }
 
+    TextField(
+        value = text,
+        onValueChange = { text = it },
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 0.dp)
+            .background(color = Color.Unspecified),
+        textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
+        label = { Text(text = "닉네임", fontFamily = laundryGothic) },
+        placeholder = {
+            Text(
+                text = "닉네임을 입력해주세요.",
+                color = PomoroDoTheme.colorScheme.gray50,
+                style = PomoroDoTheme.typography.laundryGothicRegular16
+            )
+        },
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        singleLine = true,
+        shape = RoundedCornerShape(size = 5.dp),
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = PomoroDoTheme.colorScheme.background,
+            unfocusedContainerColor = PomoroDoTheme.colorScheme.background,
+            focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
+            focusedLabelColor = PomoroDoTheme.colorScheme.primaryContainer
+        )
+    )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -64,7 +64,7 @@ fun SignUpScreen() {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "회원 정보 입력",
+            text = stringResource(R.string.title_sign_up),
             color = PomoroDoTheme.colorScheme.onBackground,
             style = PomoroDoTheme.typography.laundryGothicBold20
         )
@@ -143,10 +143,10 @@ fun ProfileEditText(text: MutableState<String>) {
             visualTransformation = VisualTransformation.None,
             interactionSource = interactionSource,
             isError = false,
-            label = { Text(text = "닉네임", fontFamily = laundryGothic) },
+            label = { Text(text = stringResource(R.string.content_user_name_label), fontFamily = laundryGothic) },
             placeholder = {
                 Text(
-                    text = "닉네임을 입력해주세요.",
+                    text = stringResource(R.string.content_user_name_placeholder),
                     color = PomoroDoTheme.colorScheme.gray50,
                     style = PomoroDoTheme.typography.laundryGothicRegular16
                 )
@@ -180,6 +180,6 @@ fun SubmitButton(enable: Boolean = false) {
         ),
         contentPadding = PaddingValues(vertical = 12.dp)
     ) {
-        Text(text = "가입", style = PomoroDoTheme.typography.laundryGothicRegular18)
+        Text(text = stringResource(R.string.content_button_sign_up), style = PomoroDoTheme.typography.laundryGothicRegular18)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -28,11 +28,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +55,9 @@ import com.tico.pomorodo.ui.theme.laundryGothic
 
 @Composable
 fun SignUpScreen() {
+    val text = rememberSaveable { mutableStateOf("") }
+    val enable = text.value.isNotBlank()
+
     Column(
         modifier = Modifier.padding(horizontal = 30.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.Top,
@@ -69,9 +71,9 @@ fun SignUpScreen() {
         Spacer(modifier = Modifier.height(20.dp))
         IconDefaultProfile()
         Spacer(modifier = Modifier.height(18.dp))
-        ProfileEditText()
+        ProfileEditText(text)
         Spacer(modifier = Modifier.height(20.dp))
-        SubmitButton()
+        SubmitButton(enable)
     }
 }
 
@@ -115,14 +117,13 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileEditText() {
-    var text by rememberSaveable { mutableStateOf("") }
+fun ProfileEditText(text: MutableState<String>) {
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
 
     BasicTextField(
-        value = text,
-        onValueChange = { text = it },
+        value = text.value,
+        onValueChange = { text.value = it },
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 0.dp),
@@ -135,7 +136,7 @@ fun ProfileEditText() {
         interactionSource = interactionSource
     ) { innerTextField ->
         TextFieldDefaults.DecorationBox(
-            value = text,
+            value = text.value,
             innerTextField = innerTextField,
             enabled = true,
             singleLine = true,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -3,8 +3,10 @@ package com.tico.pomorodo.ui.auth.view
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -12,16 +14,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -33,6 +37,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -95,40 +100,52 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun ProfileEditText() {
-    val focusManager = LocalFocusManager.current
     var text by rememberSaveable { mutableStateOf("") }
+    val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
 
-    TextField(
+    BasicTextField(
         value = text,
         onValueChange = { text = it },
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 0.dp)
-            .background(color = Color.Unspecified),
+            .heightIn(min = 0.dp),
         textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
-        label = { Text(text = "닉네임", fontFamily = laundryGothic) },
-        placeholder = {
-            Text(
-                text = "닉네임을 입력해주세요.",
-                color = PomoroDoTheme.colorScheme.gray50,
-                style = PomoroDoTheme.typography.laundryGothicRegular16
-            )
-        },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
             imeAction = ImeAction.Done
         ),
         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-        singleLine = true,
-        shape = RoundedCornerShape(size = 5.dp),
-        colors = TextFieldDefaults.colors(
-            focusedContainerColor = PomoroDoTheme.colorScheme.background,
-            unfocusedContainerColor = PomoroDoTheme.colorScheme.background,
-            focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
-            focusedLabelColor = PomoroDoTheme.colorScheme.primaryContainer
+        interactionSource = interactionSource
+    ) { innerTextField ->
+        TextFieldDefaults.DecorationBox(
+            value = text,
+            innerTextField = innerTextField,
+            enabled = true,
+            singleLine = true,
+            visualTransformation = VisualTransformation.None,
+            interactionSource = interactionSource,
+            isError = false,
+            label = { Text(text = "닉네임", fontFamily = laundryGothic) },
+            placeholder = {
+                Text(
+                    text = "닉네임을 입력해주세요.",
+                    color = PomoroDoTheme.colorScheme.gray50,
+                    style = PomoroDoTheme.typography.laundryGothicRegular16
+                )
+            },
+            shape = RoundedCornerShape(size = 5.dp),
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = PomoroDoTheme.colorScheme.background,
+                unfocusedContainerColor = PomoroDoTheme.colorScheme.background,
+                focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
+                focusedLabelColor = PomoroDoTheme.colorScheme.primaryContainer
+            ),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 14.dp)
         )
-    )
+    }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/IcProfileDefault.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/IcProfileDefault.kt
@@ -1,0 +1,67 @@
+package com.tico.pomorodo.ui.iconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.tico.pomorodo.ui.theme.IconPack
+
+val IconPack.IcProfileDefault: ImageVector
+    get() {
+        if (_icProfileDefault != null) {
+            return _icProfileDefault!!
+        }
+        _icProfileDefault = Builder(
+            name = "IcProfileDefault", defaultWidth = 150.0.dp,
+            defaultHeight = 150.0.dp, viewportWidth = 150.0f, viewportHeight = 150.0f
+        ).apply {
+            group {
+                path(
+                    fill = SolidColor(Color(0xFFD9D9D9)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(75.0f, 0.0f)
+                    lineTo(75.0f, 0.0f)
+                    arcTo(75.0f, 75.0f, 0.0f, false, true, 150.0f, 75.0f)
+                    lineTo(150.0f, 75.0f)
+                    arcTo(75.0f, 75.0f, 0.0f, false, true, 75.0f, 150.0f)
+                    lineTo(75.0f, 150.0f)
+                    arcTo(75.0f, 75.0f, 0.0f, false, true, 0.0f, 75.0f)
+                    lineTo(0.0f, 75.0f)
+                    arcTo(75.0f, 75.0f, 0.0f, false, true, 75.0f, 0.0f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0xFFB4B4B4)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(75.0f, 168.0f)
+                    moveToRelative(-75.0f, 0.0f)
+                    arcToRelative(75.0f, 75.0f, 0.0f, true, true, 150.0f, 0.0f)
+                    arcToRelative(75.0f, 75.0f, 0.0f, true, true, -150.0f, 0.0f)
+                }
+                path(
+                    fill = SolidColor(Color(0xFFB4B4B4)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(75.0f, 57.0f)
+                    moveToRelative(-32.0f, 0.0f)
+                    arcToRelative(32.0f, 32.0f, 0.0f, true, true, 64.0f, 0.0f)
+                    arcToRelative(32.0f, 32.0f, 0.0f, true, true, -64.0f, 0.0f)
+                }
+            }
+        }
+            .build()
+        return _icProfileDefault!!
+    }
+
+private var _icProfileDefault: ImageVector? = null

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -10,6 +10,10 @@
     <string name="title_todo">할 일 목록</string>
     <string name="title_my_info">내 정보</string>
     // sign up
+    <string name="title_sign_up">회원 정보 입력</string>
     <string name="content_ic_profile_default">default icon in profile change page</string>
     <string name="content_profile_change">변경</string>
+    <string name="content_user_name_label">닉네임</string>
+    <string name="content_user_name_placeholder">닉네임을 입력해주세요.</string>
+    <string name="content_button_sign_up">가입</string>
 </resources>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="title_timer">타이머</string>
     <string name="title_todo">할 일 목록</string>
     <string name="title_my_info">내 정보</string>
+    // sign up
+    <string name="content_ic_profile_default">default icon in profile change page</string>
+    <string name="content_profile_change">변경</string>
 </resources>

--- a/Mobile/PomoroDo/gradle/libs.versions.toml
+++ b/Mobile/PomoroDo/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ hilt = "2.44"
 # material3 최신 버전 적용을 위한 라이브러리
 material3 = "1.2.1"
 material3-navigation = "1.3.0-beta02"
+# url 을 사용한 이미지 로딩을 위한 라이브러리
+glide-compose = "2.3.4"
 
 
 [libraries]
@@ -51,6 +53,8 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 material3-window = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3" }
 material3-navigation = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "material3-navigation" }
+# url 을 사용한 이미지 로딩을 위한 라이브러리
+glide-compose = { group = "com.github.skydoves", name = "landscapist-glide", version.ref = "glide-compose" }
 
 
 [bundles]


### PR DESCRIPTION
회원가입 화면을 구현함.
- 프로필 변경 아이콘
  - 구글 프로필을 받아오지 않을 경우 기본 프로필을 나타냄
  - 구글 프로필 링크를 jetpack glide를 통해 나타냄
- 닉네임 입력 텍스트 박스
  - BasicTextField를 이용하여 구현
  - focused 상태일 때 label과 indicator가 primary-container 컬러로 변함.
- 가입 버튼
  - 닉네임 입력 시 가입 버튼 활성화.

Resolves: TICO-32
Related to: TICO-20