### PR TITLE
[FEAT] 집중 종료 후 화면 구현(TICO-54)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
@@ -5,8 +5,8 @@ import com.tico.pomorodo.data.model.InviteCategory
 import com.tico.pomorodo.data.model.TimeLineData
 import com.tico.pomorodo.data.model.TimeLineType
 import com.tico.pomorodo.data.model.TodoData
-import com.tico.pomorodo.data.model.User
 import com.tico.pomorodo.data.model.TodoState
+import com.tico.pomorodo.data.model.User
 import java.time.LocalDateTime
 
 object DataSource {
@@ -36,6 +36,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 1",
                     state = TodoState.UNCHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -43,6 +44,7 @@ object DataSource {
                     id = "2",
                     name = "Todo 1",
                     state = TodoState.CHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 1,
                     likedNumber = 22
                 ),
@@ -50,6 +52,7 @@ object DataSource {
                     id = "3",
                     name = "Todo 1",
                     state = TodoState.GOING,
+                    categoryId = "1",
                     completeGroupNumber = 3,
                     likedNumber = 22
                 ),
@@ -57,6 +60,7 @@ object DataSource {
                     id = "4",
                     name = "Todo 1",
                     state = TodoState.UNCHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 0,
                     likedNumber = 0
                 )
@@ -70,6 +74,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 1",
                     state = TodoState.UNCHECKED,
+                    categoryId = "3",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -83,6 +88,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 1",
                     state = TodoState.UNCHECKED,
+                    categoryId = "3",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -90,6 +96,7 @@ object DataSource {
                     id = "2",
                     name = "Todo 1",
                     state = TodoState.CHECKED,
+                    categoryId = "3",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -125,6 +132,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 1",
                     state = TodoState.GOING,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -132,6 +140,7 @@ object DataSource {
                     id = "2",
                     name = "Todo 2",
                     state = TodoState.GOING,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -151,6 +160,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 4",
                     state = TodoState.GOING,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -158,6 +168,7 @@ object DataSource {
                     id = "2",
                     name = "Todo 2",
                     state = TodoState.CHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -177,6 +188,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 4",
                     state = TodoState.CHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -184,6 +196,7 @@ object DataSource {
                     id = "2",
                     name = "Todo 5",
                     state = TodoState.CHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -203,6 +216,7 @@ object DataSource {
                     id = "1",
                     name = "Todo 4",
                     state = TodoState.CHECKED,
+                    categoryId = "1",
                     completeGroupNumber = 4,
                     likedNumber = 22
                 ),
@@ -226,6 +240,7 @@ object DataSource {
             id = "1",
             name = "Todo 1",
             state = TodoState.UNCHECKED,
+            categoryId = "1",
             completeGroupNumber = 4,
             likedNumber = 22
         ),
@@ -233,6 +248,7 @@ object DataSource {
             id = "2",
             name = "Todo 1",
             state = TodoState.CHECKED,
+            categoryId = "1",
             completeGroupNumber = 1,
             likedNumber = 22
         ),
@@ -240,6 +256,7 @@ object DataSource {
             id = "3",
             name = "Todo 1",
             state = TodoState.GOING,
+            categoryId = "1",
             completeGroupNumber = 3,
             likedNumber = 22
         ),
@@ -247,6 +264,7 @@ object DataSource {
             id = "4",
             name = "Todo 1",
             state = TodoState.UNCHECKED,
+            categoryId = "1",
             completeGroupNumber = 0,
             likedNumber = 0
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/TodoData.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/TodoData.kt
@@ -4,6 +4,7 @@ data class TodoData(
     val id: String,
     val name: String,
     var state: TodoState,
+    var categoryId: String,
     val completeGroupNumber: Int? = null,
     val likedNumber: Int = 0,
 )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -10,7 +10,8 @@ fun AppNavHost(
     appState: AppState,
     modifier: Modifier = Modifier,
     startDestination: String = BottomNavigationDestination.Timer.name,
-    navigateToConcentrationMode: () -> Unit
+    navigateToConcentrationMode: () -> Unit,
+    setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit,
 ) {
     val navController = appState.navController
     NavHost(
@@ -18,7 +19,7 @@ fun AppNavHost(
         startDestination = startDestination,
         modifier = modifier
     ) {
-        timerScreen(navigate = navigateToConcentrationMode)
+        timerScreen(setState = setTimerState, navigate = navigateToConcentrationMode)
         todoScreen()
         myInfoScreen()
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -32,9 +32,12 @@ fun NavController.navigateToConcentrationMode() =
 
 
 // home navigation - composable route
-fun NavGraphBuilder.timerScreen(navigate: () -> Unit) {
+fun NavGraphBuilder.timerScreen(
+    setState: (concentrationTime: Int, breakTime: Int) -> Unit,
+    navigate: () -> Unit
+) {
     composable(route = BottomNavigationDestination.Timer.name) {
-        TimerRootScreen(navigate = navigate)
+        TimerRootScreen(setState = setState, navigate = navigate)
     }
 }
 
@@ -69,14 +72,20 @@ fun NavGraphBuilder.signUpScreen(navigate: () -> Unit) {
     }
 }
 
-fun NavGraphBuilder.homeScreen(navigateToConcentrationMode: () -> Unit) {
+fun NavGraphBuilder.homeScreen(
+    setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit,
+    navigateToConcentrationMode: () -> Unit
+) {
     composable(route = MainNavigationDestination.Home.name) {
-        HomeScreen(navigateToConcentrationMode = navigateToConcentrationMode)
+        HomeScreen(
+            setTimerState = setTimerState,
+            navigateToConcentrationMode = navigateToConcentrationMode
+        )
     }
 }
 
-fun NavGraphBuilder.concentrationModeScreen() {
+fun NavGraphBuilder.concentrationModeScreen(getState: (String)-> Int?) {
     composable(route = MainNavigationDestination.ConcentrationMode.name) {
-        ConcentrationTimerScreen()
+        ConcentrationTimerScreen(getState = getState)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -10,8 +10,8 @@ import com.tico.pomorodo.ui.home.view.HomeScreen
 import com.tico.pomorodo.ui.home.view.MyInfoScreen
 import com.tico.pomorodo.ui.home.view.TodoScreen
 import com.tico.pomorodo.ui.splash.view.SplashScreen
-import com.tico.pomorodo.ui.timer.view.ConcentrationTimerScreen
-import com.tico.pomorodo.ui.timer.view.TimerRootScreen
+import com.tico.pomorodo.ui.timer.running.view.ConcentrationTimerScreen
+import com.tico.pomorodo.ui.timer.setup.view.TimerRootScreen
 
 // home navigation - navigate
 fun NavController.navigateToTimer(navOptions: NavOptions) =

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavControllerExtensions.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavControllerExtensions.kt
@@ -1,0 +1,10 @@
+package com.tico.pomorodo.navigation
+
+import androidx.navigation.NavController
+
+fun NavController.setState(key: String, value: Any) {
+    this.currentBackStackEntry?.savedStateHandle?.set(key, value)
+}
+
+fun <T> NavController.getState(key: String): T? =
+    this.previousBackStackEntry?.savedStateHandle?.get(key)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -10,14 +10,18 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.navigation.concentrationModeScreen
+import com.tico.pomorodo.navigation.getState
 import com.tico.pomorodo.navigation.homeScreen
 import com.tico.pomorodo.navigation.logInScreen
 import com.tico.pomorodo.navigation.navigateToConcentrationMode
 import com.tico.pomorodo.navigation.navigateToHome
 import com.tico.pomorodo.navigation.navigateToLogIn
 import com.tico.pomorodo.navigation.navigateToSignUp
+import com.tico.pomorodo.navigation.setState
 import com.tico.pomorodo.navigation.signUpScreen
 import com.tico.pomorodo.navigation.splashScreen
+import com.tico.pomorodo.ui.common.view.BREAK_TIME
+import com.tico.pomorodo.ui.common.view.CONCENTRATION_TIME
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
@@ -39,8 +43,14 @@ fun MainScreen() {
                 splashScreen(navigate = mainNavController::navigateToLogIn)
                 logInScreen(navigate = mainNavController::navigateToSignUp)
                 signUpScreen(navigate = mainNavController::navigateToHome)
-                homeScreen(navigateToConcentrationMode = mainNavController::navigateToConcentrationMode)
-                concentrationModeScreen()
+                homeScreen(
+                    setTimerState = { concentrationTime, breakTime ->
+                        mainNavController.setState(CONCENTRATION_TIME, concentrationTime)
+                        mainNavController.setState(BREAK_TIME, breakTime)
+                    },
+                    navigateToConcentrationMode = mainNavController::navigateToConcentrationMode
+                )
+                concentrationModeScreen(getState = mainNavController::getState)
             }
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupDeleteDialogs.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupDeleteDialogs.kt
@@ -23,7 +23,7 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Composable
 fun GroupDeleteFirstDialog(
     onConfirmation: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
 ) {
     SimpleAlertDialog(
         dialogTitleId = R.string.title_group_delete,
@@ -49,7 +49,7 @@ fun GroupDeleteSecondDialog(
     value: String,
     onValueChange: (String) -> Unit,
     onConfirmation: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
 ) {
     val textFieldColors = TextFieldDefaults.colors(
         focusedTextColor = PomoroDoTheme.colorScheme.onBackground,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
@@ -158,7 +158,7 @@ fun InfoCategoryScreenRoute(viewModel: CategoryViewModel = hiltViewModel()) {
                 if (groupDeleteDialogVisible) {
                     GroupDeleteFirstDialog(
                         onConfirmation = { },
-                        onDismissRequest = { groupDeleteDialogVisible = it }
+                        onDismissRequest = { groupDeleteDialogVisible = false }
                     )
                 }
                 if (groupOutDialogVisible) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Constants.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Constants.kt
@@ -1,0 +1,4 @@
+package com.tico.pomorodo.ui.common.view
+
+const val CONCENTRATION_TIME = "concentrationTime"
+const val BREAK_TIME = "breakTime"

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/SimpleAlertDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/SimpleAlertDialog.kt
@@ -30,12 +30,12 @@ fun SimpleAlertDialog(
     dismissTextId: Int,
     enabled: Boolean = true,
     onConfirmation: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     val colors = CardDefaults.cardColors(containerColor = PomoroDoTheme.colorScheme.dialogSurface)
     Dialog(
-        onDismissRequest = { onDismissRequest(false) },
+        onDismissRequest = onDismissRequest,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         Card(
@@ -69,7 +69,7 @@ fun SimpleAlertDialog(
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
                         verticalPadding = 8.dp,
                         horizontalPadding = 20.dp,
-                        onClick = { onDismissRequest(false) }
+                        onClick = onDismissRequest
                     )
                     CustomTextButton(
                         text = stringResource(id = confirmTextId),

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoItem.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoItem.kt
@@ -19,7 +19,7 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 fun TodoItem(
     iconSize: Int,
     todoData: TodoData,
-    enabled: Boolean,
+    enabled: Boolean = true,
     textStyle: TextStyle,
     onStateChanged: ((TodoState) -> Unit)? = null
 ) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoItem.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoItem.kt
@@ -1,0 +1,67 @@
+package com.tico.pomorodo.ui.common.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.tico.pomorodo.R
+import com.tico.pomorodo.data.model.TodoData
+import com.tico.pomorodo.data.model.TodoState
+import com.tico.pomorodo.ui.theme.IC_TODO_CHECKED
+import com.tico.pomorodo.ui.theme.IC_TODO_GOING
+import com.tico.pomorodo.ui.theme.IC_TODO_UNCHECKED
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun TodoItem(
+    iconSize: Int,
+    todoData: TodoData,
+    enabled: Boolean,
+    textStyle: TextStyle,
+    onStateChanged: ((TodoState) -> Unit)? = null
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        TodoCheckBox(
+            size = iconSize,
+            state = todoData.state,
+            enabled = enabled,
+            onStateChanged = { onStateChanged?.invoke(it) })
+        SimpleText(
+            modifier = Modifier,
+            text = todoData.name,
+            style = textStyle,
+            color = PomoroDoTheme.colorScheme.onBackground
+        )
+    }
+}
+
+@Composable
+private fun TodoCheckBox(
+    size: Int,
+    state: TodoState,
+    onStateChanged: (TodoState) -> Unit,
+    enabled: Boolean
+) {
+    SimpleIcon(
+        modifier = Modifier.clickableWithoutRipple(enabled) {
+            onStateChanged(state)
+        },
+        size = size,
+        imageVector = when (state) {
+            TodoState.UNCHECKED -> PomoroDoTheme.iconPack[IC_TODO_UNCHECKED]!!
+            TodoState.GOING -> PomoroDoTheme.iconPack[IC_TODO_GOING]!!
+            TodoState.CHECKED -> PomoroDoTheme.iconPack[IC_TODO_CHECKED]!!
+        },
+        contentDescriptionId = when (state) {
+            TodoState.UNCHECKED -> R.string.content_todo_unchecked
+            TodoState.GOING -> R.string.content_todo_going
+            TodoState.CHECKED -> R.string.content_todo_checked
+        }
+    )
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoListDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoListDialog.kt
@@ -50,9 +50,9 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
  * @param title The title of the dialog.
  * @param todoList The list of to-do items to display in the dialog.
  * @param confirmTextId The resource ID for the text on the confirm button.
- * @param confirmEnable Whether the confirm button is enabled.
  * @param onConfirmation Function to run when the confirm button is clicked.
- * @param onDismissRequest Function to run when the dismiss button is clicked.
+ * @param onResetRequest Function to run when the dismiss button is clicked.
+ * @param onDismissRequest Function to run when the outside of dialog or back button is clicked.
  * @param onTodoStateChanged Function to run when the state of a to-do item is changed.
  */
 @Composable
@@ -60,16 +60,16 @@ fun TodoListDialog(
     title: String,
     todoList: List<TodoData>,
     @StringRes confirmTextId: Int,
-    confirmEnable: Boolean = true,
     onConfirmation: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onResetRequest: () -> Unit,
+    onDismissRequest: () -> Unit,
     onTodoStateChanged: (index: Int, todoState: TodoState) -> Unit
 ) {
     val colors = CardDefaults.cardColors(containerColor = PomoroDoTheme.colorScheme.dialogSurface)
     val textColor = PomoroDoTheme.colorScheme.onBackground
 
     Dialog(
-        onDismissRequest = { onDismissRequest(false) },
+        onDismissRequest = onDismissRequest,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         Card(
@@ -117,7 +117,7 @@ fun TodoListDialog(
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
                         verticalPadding = 8.dp,
                         horizontalPadding = 20.dp,
-                        onClick = { onDismissRequest(false) }
+                        onClick = onResetRequest
                     )
                     CustomTextButton(
                         text = stringResource(id = confirmTextId),
@@ -126,10 +126,7 @@ fun TodoListDialog(
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
                         verticalPadding = 8.dp,
                         horizontalPadding = 20.dp,
-                        enabled = confirmEnable,
-                        onClick = onConfirmation,
-                        disabledContentColor = Color.White,
-                        disabledContainerColor = PomoroDoTheme.colorScheme.dialogGray70
+                        onClick = onConfirmation
                     )
                 }
             }
@@ -167,6 +164,7 @@ fun PreviewDialog() {
             todoList = todoList,
             confirmTextId = R.string.content_ok,
             onConfirmation = { /*TODO*/ },
+            onResetRequest = { /*TODO*/ },
             onDismissRequest = { /*TODO*/ },
             onTodoStateChanged = { index, todoState -> /*TODO*/ }
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoListDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/TodoListDialog.kt
@@ -1,0 +1,174 @@
+package com.tico.pomorodo.ui.common.view
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.tico.pomorodo.R
+import com.tico.pomorodo.data.local.datasource.DataSource.todoList
+import com.tico.pomorodo.data.model.TodoData
+import com.tico.pomorodo.data.model.TodoState
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+/**
+ * Displays a dialog showing a list of to-do items.
+ *
+ * This dialog can be used in two scenarios:
+ * 1. After completing a concentration session, it shows today's remaining to-do items for the user to check off.
+ * 2. When editing the timeline, it shows all to-do items, including completed ones, for the user to update.
+ *
+ * The dialog includes:
+ * - A title.
+ * - A list of to-do items.
+ * - A dismiss button that resets any changes made.
+ * - A confirm button that applies the changes.
+ *
+ * Example usage:
+ *
+ * @sample PreviewDialog
+ *
+ * @param title The title of the dialog.
+ * @param todoList The list of to-do items to display in the dialog.
+ * @param confirmTextId The resource ID for the text on the confirm button.
+ * @param confirmEnable Whether the confirm button is enabled.
+ * @param onConfirmation Function to run when the confirm button is clicked.
+ * @param onDismissRequest Function to run when the dismiss button is clicked.
+ * @param onTodoStateChanged Function to run when the state of a to-do item is changed.
+ */
+@Composable
+fun TodoListDialog(
+    title: String,
+    todoList: List<TodoData>,
+    @StringRes confirmTextId: Int,
+    confirmEnable: Boolean = true,
+    onConfirmation: () -> Unit,
+    onDismissRequest: (Boolean) -> Unit,
+    onTodoStateChanged: (index: Int, todoState: TodoState) -> Unit
+) {
+    val colors = CardDefaults.cardColors(containerColor = PomoroDoTheme.colorScheme.dialogSurface)
+    val textColor = PomoroDoTheme.colorScheme.onBackground
+
+    Dialog(
+        onDismissRequest = { onDismissRequest(false) },
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Card(
+            modifier = Modifier.padding(horizontal = 40.dp),
+            shape = RoundedCornerShape(15.dp),
+            colors = colors,
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 18.dp, vertical = 24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = title,
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    style = PomoroDoTheme.typography.laundryGothicBold20
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Text(
+                    text = stringResource(R.string.content_todo_list_dialog),
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    style = PomoroDoTheme.typography.laundryGothicRegular14
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TodoList(todoList = todoList, onStateChanged = onTodoStateChanged)
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    modifier = Modifier.align(Alignment.End),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CustomTextButton(
+                        text = stringResource(id = R.string.content_reset),
+                        containerColor = Color.Unspecified,
+                        contentColor = PomoroDoTheme.colorScheme.onBackground,
+                        textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
+                        verticalPadding = 8.dp,
+                        horizontalPadding = 20.dp,
+                        onClick = { onDismissRequest(false) }
+                    )
+                    CustomTextButton(
+                        text = stringResource(id = confirmTextId),
+                        containerColor = PomoroDoTheme.colorScheme.primaryContainer,
+                        contentColor = Color.White,
+                        textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
+                        verticalPadding = 8.dp,
+                        horizontalPadding = 20.dp,
+                        enabled = confirmEnable,
+                        onClick = onConfirmation,
+                        disabledContentColor = Color.White,
+                        disabledContainerColor = PomoroDoTheme.colorScheme.dialogGray70
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodoList(
+    todoList: List<TodoData>,
+    onStateChanged: (index: Int, todoState: TodoState) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        itemsIndexed(items = todoList, key = { _, todoData -> todoData.id }) { index, todoItem ->
+            TodoItem(
+                iconSize = 24,
+                todoData = todoItem,
+                onStateChanged = { todoState -> onStateChanged(index, todoState) },
+                textStyle = PomoroDoTheme.typography.laundryGothicRegular16
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewDialog() {
+    PomoroDoTheme {
+        TodoListDialog(
+            title = "할 일 목록",
+            todoList = todoList,
+            confirmTextId = R.string.content_ok,
+            onConfirmation = { /*TODO*/ },
+            onDismissRequest = { /*TODO*/ },
+            onTodoStateChanged = { index, todoState -> /*TODO*/ }
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryDeleteDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryDeleteDialog.kt
@@ -10,7 +10,7 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Composable
 fun HistoryDeleteDialog(
     onConfirmation: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
 ) {
     SimpleAlertDialog(
         dialogTitleId = R.string.content_history_delete,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryScreen.kt
@@ -53,13 +53,13 @@ import com.tico.pomorodo.ui.common.view.SimpleDropDownMoreInfo
 import com.tico.pomorodo.ui.common.view.SimpleIcon
 import com.tico.pomorodo.ui.common.view.SimpleIconButton
 import com.tico.pomorodo.ui.common.view.SimpleText
+import com.tico.pomorodo.ui.common.view.TodoItem
 import com.tico.pomorodo.ui.common.view.getTimeFormat
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcTimelineOrangeFilled
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcTimelineOrangeOutline
 import com.tico.pomorodo.ui.theme.IC_TIMELINE_MORE_INFO
 import com.tico.pomorodo.ui.theme.IconPack
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
-import com.tico.pomorodo.ui.todo.view.TodoItem
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/history/view/HistoryScreen.kt
@@ -95,7 +95,7 @@ fun HistoryRoute() {
             if (historyDeleteDialogVisible) {
                 HistoryDeleteDialog(
                     onConfirmation = { },
-                    onDismissRequest = { historyDeleteDialogVisible = it }
+                    onDismissRequest = { historyDeleteDialogVisible = false }
                 )
             }
             if (historyEditDialogVisible) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
@@ -10,7 +10,10 @@ import com.tico.pomorodo.navigation.BottomNavigationDestination
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
-fun HomeScreen(navigateToConcentrationMode: () -> Unit) {
+fun HomeScreen(
+    navigateToConcentrationMode: () -> Unit,
+    setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit
+) {
     val homeNavController = rememberNavController()
     val appState = AppState(homeNavController)
 
@@ -22,7 +25,8 @@ fun HomeScreen(navigateToConcentrationMode: () -> Unit) {
             appState = appState,
             Modifier.padding(innerPadding),
             startDestination = BottomNavigationDestination.Timer.name,
-            navigateToConcentrationMode = navigateToConcentrationMode
+            navigateToConcentrationMode = navigateToConcentrationMode,
+            setTimerState = setTimerState
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -58,7 +58,7 @@ fun ConcentrationTimerScreen(
             delay(1000)
 
             second = updateTimer(
-                time = concentrationTime,
+                time = concentrationTime.copy(),
                 onFinishedChange = { setFinish(true) },
                 onTimeChanged = timerRunningViewModel::setConcentrationTime
             )
@@ -85,7 +85,7 @@ fun ConcentrationTimerScreen(
 fun TimerScreenLayout(concentrationTime: Time, maxValue: Int, onClick: () -> Unit) {
     var hour by remember { mutableIntStateOf(concentrationTime.hour) }
     var minute by remember { mutableIntStateOf(concentrationTime.minute) }
-    var second by remember { mutableIntStateOf(0) }
+    val second by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(key1 = Unit) {
         hour = concentrationTime.hour

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.view
+package com.tico.pomorodo.ui.timer.running.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -29,7 +29,8 @@ import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTimeText
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
-import com.tico.pomorodo.ui.timer.viewmodel.TimerViewModel
+import com.tico.pomorodo.ui.timer.setup.view.CustomCircularTimer
+import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerViewModel
 import kotlinx.coroutines.delay
 
 @Composable

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -30,6 +30,7 @@ import com.tico.pomorodo.ui.common.view.CONCENTRATION_TIME
 import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTimeText
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
+import com.tico.pomorodo.ui.common.view.TodoListDialog
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import com.tico.pomorodo.ui.timer.running.viewmodel.TimerRunningViewModel
 import com.tico.pomorodo.ui.timer.setup.view.CustomCircularTimer
@@ -52,6 +53,7 @@ fun ConcentrationTimerScreen(
         mutableStateOf(false)
     }
     var second by remember { mutableIntStateOf(0) }
+    val todoList by timerRunningViewModel.todoList.collectAsState()
 
     LaunchedEffect(key1 = second, key2 = isPaused) {
         if (!isPaused) {
@@ -72,27 +74,40 @@ fun ConcentrationTimerScreen(
 
     if (finishTimerDialogVisible) {
         FinishTimerDialog(
-            onConfirmation = { setFinishTimerDialogVisible(false) },
+            onConfirmation = {
+                setFinish(true)
+                setFinishTimerDialogVisible(false)
+            },
             onDismissRequest = {
                 setPause(false)
                 setFinishTimerDialogVisible(false)
             }
         )
     }
+
+    if (isFinished) {
+        TodoListDialog(
+            title = stringResource(R.string.title_check_todo_list_dialog),
+            todoList = todoList,
+            confirmTextId = R.string.content_ok,
+            onConfirmation = { /*TODO*/ },
+            onResetRequest = timerRunningViewModel::resetTodoState,
+            onDismissRequest = {
+                setFinish(false)
+                setPause(false)
+                timerRunningViewModel.resetTodoState()
+            },
+            onTodoStateChanged = timerRunningViewModel::changeTodoState
+        )
+    }
 }
 
 @Composable
 fun TimerScreenLayout(concentrationTime: Time, maxValue: Int, onClick: () -> Unit) {
-    var hour by remember { mutableIntStateOf(concentrationTime.hour) }
-    var minute by remember { mutableIntStateOf(concentrationTime.minute) }
-    val second by remember { mutableIntStateOf(0) }
-
-    LaunchedEffect(key1 = Unit) {
-        hour = concentrationTime.hour
-        minute = concentrationTime.minute
-    }
-
-    val timeToSecond = hour * 60 * 60 + minute * 60 + second
+    val timeToSecond =
+        concentrationTime.hour * 60 * 60 +
+                concentrationTime.minute * 60 +
+                (concentrationTime.second ?: 0)
 
     Column(
         modifier = Modifier

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -30,13 +30,13 @@ import com.tico.pomorodo.ui.common.view.CustomTimeText
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import com.tico.pomorodo.ui.timer.setup.view.CustomCircularTimer
-import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerViewModel
+import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerSetupViewModel
 import kotlinx.coroutines.delay
 
 @Composable
-fun ConcentrationTimerScreen(timerViewModel: TimerViewModel = hiltViewModel()) {
-    val concentrationTime by timerViewModel.concentrationTime.collectAsState()
-    val maxValue by timerViewModel.timerMaxValue.collectAsState()
+fun ConcentrationTimerScreen(timerSetupViewModel: TimerSetupViewModel = hiltViewModel()) {
+    val concentrationTime by timerSetupViewModel.concentrationTime.collectAsState()
+    val maxValue by timerSetupViewModel.timerMaxValue.collectAsState()
     var hour by remember { mutableIntStateOf(concentrationTime.hour) }
     var minute by remember { mutableIntStateOf(concentrationTime.minute) }
     var second by remember { mutableIntStateOf(concentrationTime.second ?: 0) }
@@ -68,7 +68,7 @@ fun ConcentrationTimerScreen(timerViewModel: TimerViewModel = hiltViewModel()) {
                 }
             }
 
-            timerViewModel.setConcentrationTime(hour, minute, second)
+            timerSetupViewModel.setConcentrationTime(hour, minute, second)
         }
     }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
@@ -1,0 +1,40 @@
+package com.tico.pomorodo.ui.timer.running.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.tico.pomorodo.data.model.Time
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class TimerRunningViewModel @Inject constructor(private val savedStateHandle: SavedStateHandle) :
+    ViewModel() {
+    private val _concentrationTime: MutableStateFlow<Time> = MutableStateFlow(Time())
+    val concentrationTime: StateFlow<Time> = _concentrationTime
+
+    private val _breakTime: MutableStateFlow<Time> = MutableStateFlow(Time())
+    val breakTime: StateFlow<Time> = _breakTime
+
+    private val _timerMaxValue: MutableStateFlow<Int> = MutableStateFlow(0)
+    val timerMaxValue: StateFlow<Int> = _timerMaxValue
+
+    fun initialConcentrationTime(time: Int) {
+        _concentrationTime.value = Time(time / 60, time % 60, 0)
+        _timerMaxValue.value = time * 60
+    }
+
+    fun initialBreakTime(time: Int) {
+        _concentrationTime.value = Time(time / 60, time % 60, 0)
+        _timerMaxValue.value = time * 60
+    }
+
+    fun setConcentrationTime(hour: Int, minute: Int, second: Int? = null) {
+        _concentrationTime.value = Time(hour, minute, second)
+    }
+
+    fun setBreakTime(hour: Int, minute: Int) {
+        _breakTime.value = Time(hour, minute)
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
@@ -2,7 +2,10 @@ package com.tico.pomorodo.ui.timer.running.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.tico.pomorodo.data.local.datasource.DataSource
 import com.tico.pomorodo.data.model.Time
+import com.tico.pomorodo.data.model.TodoData
+import com.tico.pomorodo.data.model.TodoState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +23,10 @@ class TimerRunningViewModel @Inject constructor(private val savedStateHandle: Sa
     private val _timerMaxValue: MutableStateFlow<Int> = MutableStateFlow(0)
     val timerMaxValue: StateFlow<Int> = _timerMaxValue
 
+    private val _todoList: MutableStateFlow<List<TodoData>> = MutableStateFlow(DataSource.todoList)
+    private val _oldTodoList: MutableStateFlow<List<TodoData>> = MutableStateFlow(_todoList.value)
+    val todoList: StateFlow<List<TodoData>> = _todoList
+
     fun initialConcentrationTime(time: Int) {
         _concentrationTime.value = Time(time / 60, time % 60, 0)
         _timerMaxValue.value = time * 60
@@ -36,5 +43,21 @@ class TimerRunningViewModel @Inject constructor(private val savedStateHandle: Sa
 
     fun setBreakTime(hour: Int, minute: Int) {
         _breakTime.value = Time(hour, minute)
+    }
+
+    fun changeTodoState(todoIndex: Int, state: TodoState) {
+        val newState = when (state) {
+            TodoState.UNCHECKED -> TodoState.CHECKED
+            TodoState.CHECKED -> TodoState.GOING
+            TodoState.GOING -> TodoState.UNCHECKED
+        }
+        val newTodoList = _todoList.value.toMutableList()
+        val newItem = newTodoList[todoIndex].copy(state = newState)
+        newTodoList[todoIndex] = newItem
+        _todoList.value = newTodoList
+    }
+
+    fun resetTodoState() {
+        _todoList.value = _oldTodoList.value
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/CustomCircularTimer.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/CustomCircularTimer.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.view
+package com.tico.pomorodo.ui.timer.setup.view
 
 import android.graphics.Paint
 import android.graphics.Typeface

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/EditTimerDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/EditTimerDialog.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.view
+package com.tico.pomorodo.ui.timer.setup.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/PomodoroTimer.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/PomodoroTimer.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.view
+package com.tico.pomorodo.ui.timer.setup.view
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
@@ -24,15 +24,15 @@ import com.tico.pomorodo.data.model.Time
 import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTimeText
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
-import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerViewModel
+import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerSetupViewModel
 import kotlinx.coroutines.runBlocking
 
 @Composable
 fun TimerRootScreen(navigate: () -> Unit) {
-    val timerViewModel: TimerViewModel = hiltViewModel()
-    val concentrationTime by timerViewModel.concentrationTime.collectAsState()
-    val breakTime by timerViewModel.breakTime.collectAsState()
-    val concentrationGoal by timerViewModel.concentrationGoal.collectAsState()
+    val timerSetupViewModel: TimerSetupViewModel = hiltViewModel()
+    val concentrationTime by timerSetupViewModel.concentrationTime.collectAsState()
+    val breakTime by timerSetupViewModel.breakTime.collectAsState()
+    val concentrationGoal by timerSetupViewModel.concentrationGoal.collectAsState()
     val (editConcentrationTimerDialogVisible, setEditConcentrationTimerDialogVisible) = remember {
         mutableStateOf(false)
     }
@@ -55,13 +55,13 @@ fun TimerRootScreen(navigate: () -> Unit) {
             breakTime = breakTime,
             concentrationGoal = concentrationGoal,
             onConcentrationTimeChange = { time ->
-                timerViewModel.setConcentrationTime(
+                timerSetupViewModel.setConcentrationTime(
                     hour = time / 60,
                     minute = time % 60
                 )
             },
             onBreakTimeChange = { time ->
-                timerViewModel.setBreakTime(
+                timerSetupViewModel.setBreakTime(
                     hour = time / 60,
                     minute = time % 60
                 )
@@ -81,9 +81,9 @@ fun TimerRootScreen(navigate: () -> Unit) {
             textStyle = PomoroDoTheme.typography.laundryGothicRegular18,
             verticalPadding = 12.dp
         ) {
-            timerViewModel.setTimerMaxValue(concentrationTime.hour, concentrationTime.minute)
+            timerSetupViewModel.setTimerMaxValue(concentrationTime.hour, concentrationTime.minute)
             runBlocking {
-                timerViewModel.setConcentrationTime(
+                timerSetupViewModel.setConcentrationTime(
                     concentrationTime.hour,
                     concentrationTime.minute,
                     0
@@ -101,7 +101,7 @@ fun TimerRootScreen(navigate: () -> Unit) {
                 setEditConcentrationTimerDialogVisible(false)
             },
             onConfirmation = { hour, minute, _ ->
-                timerViewModel.setConcentrationTime(hour, minute)
+                timerSetupViewModel.setConcentrationTime(hour, minute)
                 setEditConcentrationTimerDialogVisible(false)
             }
         )
@@ -115,7 +115,7 @@ fun TimerRootScreen(navigate: () -> Unit) {
                 setEditBreakTimerDialogVisible(false)
             },
             onConfirmation = { hour, minute, _ ->
-                timerViewModel.setBreakTime(hour, minute)
+                timerSetupViewModel.setBreakTime(hour, minute)
                 setEditBreakTimerDialogVisible(false)
             }
         )
@@ -129,7 +129,7 @@ fun TimerRootScreen(navigate: () -> Unit) {
                 setEditConcentrationGoalDialogVisible(false)
             },
             onConfirmation = { hour, minute, second ->
-                timerViewModel.setConcentrationGoal(hour, minute, second!!)
+                timerSetupViewModel.setConcentrationGoal(hour, minute, second!!)
                 setEditConcentrationGoalDialogVisible(false)
             }
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.view
+package com.tico.pomorodo.ui.timer.setup.view
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,7 +24,7 @@ import com.tico.pomorodo.data.model.Time
 import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTimeText
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
-import com.tico.pomorodo.ui.timer.viewmodel.TimerViewModel
+import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerViewModel
 import kotlinx.coroutines.runBlocking
 
 @Composable

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
@@ -28,7 +28,10 @@ import com.tico.pomorodo.ui.timer.setup.viewmodel.TimerSetupViewModel
 import kotlinx.coroutines.runBlocking
 
 @Composable
-fun TimerRootScreen(navigate: () -> Unit) {
+fun TimerRootScreen(
+    setState: (concentrationTime: Int, breakTime: Int) -> Unit,
+    navigate: () -> Unit
+) {
     val timerSetupViewModel: TimerSetupViewModel = hiltViewModel()
     val concentrationTime by timerSetupViewModel.concentrationTime.collectAsState()
     val breakTime by timerSetupViewModel.breakTime.collectAsState()
@@ -81,13 +84,12 @@ fun TimerRootScreen(navigate: () -> Unit) {
             textStyle = PomoroDoTheme.typography.laundryGothicRegular18,
             verticalPadding = 12.dp
         ) {
-            timerSetupViewModel.setTimerMaxValue(concentrationTime.hour, concentrationTime.minute)
+            val concentrationTimeInMinute =
+                concentrationTime.hour * 60 + concentrationTime.minute
+            val breakTimeInMinute = breakTime.hour * 60 + breakTime.minute
+
             runBlocking {
-                timerSetupViewModel.setConcentrationTime(
-                    concentrationTime.hour,
-                    concentrationTime.minute,
-                    0
-                )
+                setState(concentrationTimeInMinute, breakTimeInMinute)
                 navigate()
             }
         }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
@@ -18,9 +18,6 @@ class TimerSetupViewModel @Inject constructor() : ViewModel() {
     private val _concentrationGoal: MutableStateFlow<Time> = MutableStateFlow(Time(0, 0, 0))
     val concentrationGoal: StateFlow<Time> = _concentrationGoal
 
-    private val _timerMaxValue: MutableStateFlow<Int> = MutableStateFlow(0)
-    val timerMaxValue: StateFlow<Int> = _timerMaxValue
-
     fun setConcentrationTime(hour: Int, minute: Int, second: Int? = null) {
         _concentrationTime.value = Time(hour, minute, second)
     }
@@ -31,9 +28,5 @@ class TimerSetupViewModel @Inject constructor() : ViewModel() {
 
     fun setConcentrationGoal(hour: Int, minute: Int, second: Int) {
         _concentrationGoal.value = Time(hour, minute, second)
-    }
-
-    fun setTimerMaxValue(hour: Int, minute: Int) {
-        _timerMaxValue.value = hour * 60 * 60 + minute * 60
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class TimerViewModel @Inject constructor() : ViewModel() {
+class TimerSetupViewModel @Inject constructor() : ViewModel() {
     private val _concentrationTime: MutableStateFlow<Time> = MutableStateFlow(Time(0, 0))
     val concentrationTime: StateFlow<Time> = _concentrationTime
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerViewModel.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.timer.viewmodel
+package com.tico.pomorodo.ui.timer.setup.viewmodel
 
 import androidx.lifecycle.ViewModel
 import com.tico.pomorodo.data.model.Time

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.tico.pomorodo.R
 import com.tico.pomorodo.data.model.TodoData
@@ -31,13 +30,12 @@ import com.tico.pomorodo.ui.common.view.SimpleDropDownMoreInfo
 import com.tico.pomorodo.ui.common.view.SimpleIcon
 import com.tico.pomorodo.ui.common.view.SimpleIconButton
 import com.tico.pomorodo.ui.common.view.SimpleText
+import com.tico.pomorodo.ui.common.view.TodoItem
 import com.tico.pomorodo.ui.common.view.clickableWithRipple
 import com.tico.pomorodo.ui.common.view.clickableWithoutRipple
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcFavoriteFilled
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcGroup
 import com.tico.pomorodo.ui.theme.IC_ADD_TODO
-import com.tico.pomorodo.ui.theme.IC_TODO_CHECKED
-import com.tico.pomorodo.ui.theme.IC_TODO_GOING
 import com.tico.pomorodo.ui.theme.IC_TODO_MORE_INFO
 import com.tico.pomorodo.ui.theme.IC_TODO_UNCHECKED
 import com.tico.pomorodo.ui.theme.IconPack
@@ -268,55 +266,4 @@ fun TodoListItem(
             }
         }
     }
-}
-
-@Composable
-fun TodoItem(
-    iconSize: Int,
-    todoData: TodoData,
-    enabled: Boolean,
-    textStyle: TextStyle,
-    onStateChanged: ((TodoState) -> Unit)? = null
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(5.dp)
-    ) {
-        TodoCheckBox(
-            size = iconSize,
-            state = todoData.state,
-            enabled = enabled,
-            onStateChanged = { onStateChanged?.invoke(it) })
-        SimpleText(
-            modifier = Modifier,
-            text = todoData.name,
-            style = textStyle,
-            color = PomoroDoTheme.colorScheme.onBackground
-        )
-    }
-}
-
-@Composable
-private fun TodoCheckBox(
-    size: Int,
-    state: TodoState,
-    onStateChanged: (TodoState) -> Unit,
-    enabled: Boolean
-) {
-    SimpleIcon(
-        modifier = Modifier.clickableWithoutRipple(enabled) {
-            onStateChanged(state)
-        },
-        size = size,
-        imageVector = when (state) {
-            TodoState.UNCHECKED -> PomoroDoTheme.iconPack[IC_TODO_UNCHECKED]!!
-            TodoState.GOING -> PomoroDoTheme.iconPack[IC_TODO_GOING]!!
-            TodoState.CHECKED -> PomoroDoTheme.iconPack[IC_TODO_CHECKED]!!
-        },
-        contentDescriptionId = when (state) {
-            TodoState.UNCHECKED -> R.string.content_todo_unchecked
-            TodoState.GOING -> R.string.content_todo_going
-            TodoState.CHECKED -> R.string.content_todo_checked
-        }
-    )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
@@ -5,8 +5,8 @@ import com.tico.pomorodo.data.local.datasource.DataSource
 import com.tico.pomorodo.data.model.Category
 import com.tico.pomorodo.data.model.InviteCategory
 import com.tico.pomorodo.data.model.TodoData
-import com.tico.pomorodo.data.model.User
 import com.tico.pomorodo.data.model.TodoState
+import com.tico.pomorodo.data.model.User
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -63,6 +63,7 @@ class TodoViewModel() : ViewModel() {
                 id = "4",
                 name = inputText.value,
                 state = TodoState.UNCHECKED,
+                categoryId = "1",
                 completeGroupNumber = 0
             )
             val newList = categoryList.value.toMutableList()

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="content_button_finish_concentration">집중 종료</string>
     <string name="title_finish_concentration">집중 모드 종료</string>
     <string name="content_finish_concentration">집중 모드를 종료하시겠습니까?</string>
+    <string name="title_check_todo_list_dialog">할 일 목록</string>
 
     // common
     <string name="content_next">다음</string>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="content_ok">확인</string>
     <string name="content_delete">삭제</string>
     <string name="content_finish">종료</string>
+    <string name="content_reset">초기화</string>
 
     // time format
     <string name="format_hour_minute">%02d:%02d</string>
@@ -152,4 +153,7 @@
     <string name="title_timer">타이머</string>
     <string name="title_todo">할 일 목록</string>
     <string name="title_my_info">내 정보</string>
+
+    // todo list dialog
+    <string name="content_todo_list_dialog">집중 시간동안 수행 한 일을 체크해주세요.</string>
 </resources>


### PR DESCRIPTION
### 추가된 내용
- 동일한 navController 간에 인자를 전달하고 받는 확장함수 생성 : ```NavControllerExtensions.kt```
- TodoListDialog 생성
  - dialog의 외부를 클릭하거나 뒤로가기 버튼을 클릭하면 상태 변경을 초기화하고 타이머를 재개함.
  - 초기화 버튼을 클릭하면 상태 변화가 초기화 됨.
- 집중 시작 화면 연결
  - 집중 시작 버튼 클릭 시 mainNavController의 savedStateHolder에 타이머 정보 저장


### 변경된 내용
- TodoItem Composable 함수 위치 변경
  - todo 패키지의 TodoItem과 TodoCheckBox의 위치를 common 패키지로 변경함.
- TodoData 인자 변경
  - 연결된 category의 Id 인자를 추가함.
- SimpleAlertDialog 함수 인자 변경
  - onDismissRequest를 파라미터를 받지 않는 함수로 변경함.
- ConcentrationTimerScreen 함수 내용 분리
  - 함수의 화면을 별도의 composable 함수로 분리 : ```TimerScreenLayout```, ```updateTimer```

Fixes: TICO-54
Related to: TICO-33