### PR TITLE
[FEAT] 휴식 모드 UI 구현(TICO-59)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -1,5 +1,6 @@
 package com.tico.pomorodo.navigation
 
+import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -10,6 +11,7 @@ import com.tico.pomorodo.ui.home.view.HomeScreen
 import com.tico.pomorodo.ui.home.view.MyInfoScreen
 import com.tico.pomorodo.ui.home.view.TodoScreen
 import com.tico.pomorodo.ui.splash.view.SplashScreen
+import com.tico.pomorodo.ui.timer.running.view.BreakTimerScreen
 import com.tico.pomorodo.ui.timer.running.view.ConcentrationTimerScreen
 import com.tico.pomorodo.ui.timer.setup.view.TimerRootScreen
 
@@ -29,6 +31,9 @@ fun NavController.navigateToSignUp() = navigate(MainNavigationDestination.SignUp
 fun NavController.navigateToHome() = navigate(MainNavigationDestination.Home.name)
 fun NavController.navigateToConcentrationMode() =
     navigate(MainNavigationDestination.ConcentrationMode.name)
+
+fun NavController.navigateToBreakMode() =
+    navigate(MainNavigationDestination.BreakMode.name)
 
 
 // home navigation - composable route
@@ -84,8 +89,20 @@ fun NavGraphBuilder.homeScreen(
     }
 }
 
-fun NavGraphBuilder.concentrationModeScreen(getState: (String)-> Int?) {
+fun NavGraphBuilder.concentrationModeScreen(
+    getState: (String) -> Int?,
+    navigateToBreakMode: () -> Unit
+) {
     composable(route = MainNavigationDestination.ConcentrationMode.name) {
-        ConcentrationTimerScreen(getState = getState)
+        ConcentrationTimerScreen(getState = getState, navigate = navigateToBreakMode)
+    }
+}
+
+fun NavGraphBuilder.breakModeScreen(navController: NavController) {
+    composable(route = MainNavigationDestination.BreakMode.name) { backStackEntry ->
+        val navBackStackEntry = remember(backStackEntry) {
+            navController.getBackStackEntry(MainNavigationDestination.ConcentrationMode.name)
+        }
+        BreakTimerScreen(navBackStackEntry = navBackStackEntry)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -103,6 +103,14 @@ fun NavGraphBuilder.breakModeScreen(navController: NavController) {
         val navBackStackEntry = remember(backStackEntry) {
             navController.getBackStackEntry(MainNavigationDestination.ConcentrationMode.name)
         }
-        BreakTimerScreen(navController = navController, navBackStackEntry = navBackStackEntry)
+        BreakTimerScreen(
+            navBackStackEntry = navBackStackEntry,
+            navigate = {
+                navController.popBackStack(
+                    MainNavigationDestination.Home.name,
+                    inclusive = false
+                )
+            }
+        )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -103,6 +103,6 @@ fun NavGraphBuilder.breakModeScreen(navController: NavController) {
         val navBackStackEntry = remember(backStackEntry) {
             navController.getBackStackEntry(MainNavigationDestination.ConcentrationMode.name)
         }
-        BreakTimerScreen(navBackStackEntry = navBackStackEntry)
+        BreakTimerScreen(navController = navController, navBackStackEntry = navBackStackEntry)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.tico.pomorodo.navigation.MainNavigationDestination
+import com.tico.pomorodo.navigation.breakModeScreen
 import com.tico.pomorodo.navigation.concentrationModeScreen
 import com.tico.pomorodo.navigation.getState
 import com.tico.pomorodo.navigation.homeScreen
 import com.tico.pomorodo.navigation.logInScreen
+import com.tico.pomorodo.navigation.navigateToBreakMode
 import com.tico.pomorodo.navigation.navigateToConcentrationMode
 import com.tico.pomorodo.navigation.navigateToHome
 import com.tico.pomorodo.navigation.navigateToLogIn
@@ -50,7 +52,11 @@ fun MainScreen() {
                     },
                     navigateToConcentrationMode = mainNavController::navigateToConcentrationMode
                 )
-                concentrationModeScreen(getState = mainNavController::getState)
+                concentrationModeScreen(
+                    getState = mainNavController::getState,
+                    mainNavController::navigateToBreakMode
+                )
+                breakModeScreen(navController = mainNavController)
             }
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
@@ -11,15 +11,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
 import com.tico.pomorodo.R
-import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import com.tico.pomorodo.ui.timer.running.viewmodel.TimerRunningViewModel
 import kotlinx.coroutines.delay
 
 @Composable
-fun BreakTimerScreen(navController: NavController, navBackStackEntry: NavBackStackEntry) {
+fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry, navigate: () -> Unit) {
     val timerRunningViewModel: TimerRunningViewModel = hiltViewModel(navBackStackEntry)
 
     LaunchedEffect(key1 = Unit) {
@@ -47,7 +45,7 @@ fun BreakTimerScreen(navController: NavController, navBackStackEntry: NavBackSta
         }
 
         if (isFinished) {
-            navController.popBackStack(MainNavigationDestination.Home.name, inclusive = false)
+            navigate()
         }
     }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
@@ -11,13 +11,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
 import com.tico.pomorodo.R
+import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import com.tico.pomorodo.ui.timer.running.viewmodel.TimerRunningViewModel
 import kotlinx.coroutines.delay
 
 @Composable
-fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
+fun BreakTimerScreen(navController: NavController, navBackStackEntry: NavBackStackEntry) {
     val timerRunningViewModel: TimerRunningViewModel = hiltViewModel(navBackStackEntry)
 
     LaunchedEffect(key1 = Unit) {
@@ -33,7 +35,7 @@ fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
     }
     var second by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(key1 = second, key2 = isPaused) {
+    LaunchedEffect(key1 = second, key2 = isPaused, key3 = isFinished) {
         if (!isPaused) {
             delay(1000)
 
@@ -42,6 +44,10 @@ fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
                 onFinishedChange = { setFinish(true) },
                 onTimeChanged = timerRunningViewModel::setBreakTime
             )
+        }
+
+        if (isFinished) {
+            navController.popBackStack(MainNavigationDestination.Home.name, inclusive = false)
         }
     }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
@@ -1,0 +1,70 @@
+package com.tico.pomorodo.ui.timer.running.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+import com.tico.pomorodo.ui.timer.running.viewmodel.TimerRunningViewModel
+import kotlinx.coroutines.delay
+
+@Composable
+fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
+    val timerRunningViewModel: TimerRunningViewModel = hiltViewModel(navBackStackEntry)
+
+    LaunchedEffect(key1 = Unit) {
+        timerRunningViewModel.initialBreakTime()
+    }
+
+    val breakTime by timerRunningViewModel.breakTime.collectAsState()
+    val maxValue by timerRunningViewModel.timerMaxValue.collectAsState()
+    val (isFinished, setFinish) = remember { mutableStateOf(false) }
+    val (isPaused, setPause) = remember { mutableStateOf(false) }
+    val (finishTimerDialogVisible, setFinishTimerDialogVisible) = remember {
+        mutableStateOf(false)
+    }
+    var second by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(key1 = second, key2 = isPaused) {
+        if (!isPaused) {
+            delay(1000)
+
+            second = updateTimer(
+                time = breakTime.copy(),
+                onFinishedChange = { setFinish(true) },
+                onTimeChanged = timerRunningViewModel::setBreakTime
+            )
+        }
+    }
+
+    TimerScreenLayout(
+        title = stringResource(id = R.string.title_break_time),
+        time = breakTime,
+        maxValue = maxValue,
+        timerColor = PomoroDoTheme.colorScheme.breakTimeColor
+    ) {
+        setPause(true)
+        setFinishTimerDialogVisible(true)
+    }
+
+    if (finishTimerDialogVisible) {
+        FinishTimerDialog(
+            onConfirmation = {
+                setFinish(true)
+                setFinishTimerDialogVisible(false)
+            },
+            onDismissRequest = {
+                setPause(false)
+                setFinishTimerDialogVisible(false)
+            }
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/BreakTimerScreen.kt
@@ -49,7 +49,8 @@ fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
         title = stringResource(id = R.string.title_break_time),
         time = breakTime,
         maxValue = maxValue,
-        timerColor = PomoroDoTheme.colorScheme.breakTimeColor
+        timerColor = PomoroDoTheme.colorScheme.breakTimeColor,
+        buttonContent = stringResource(id = R.string.content_button_finish_break)
     ) {
         setPause(true)
         setFinishTimerDialogVisible(true)
@@ -57,6 +58,8 @@ fun BreakTimerScreen(navBackStackEntry: NavBackStackEntry) {
 
     if (finishTimerDialogVisible) {
         FinishTimerDialog(
+            titleId = R.string.title_finish_break,
+            contentId = R.string.content_finish_break,
             onConfirmation = {
                 setFinish(true)
                 setFinishTimerDialogVisible(false)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -1,5 +1,6 @@
 package com.tico.pomorodo.ui.timer.running.view
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -76,7 +77,8 @@ fun ConcentrationTimerScreen(
         title = stringResource(R.string.title_concentration_time),
         time = concentrationTime,
         timerColor = PomoroDoTheme.colorScheme.primaryContainer,
-        maxValue = maxValue
+        maxValue = maxValue,
+        buttonContent = stringResource(R.string.content_button_finish_concentration)
     ) {
         setPause(true)
         setFinishTimerDialogVisible(true)
@@ -84,6 +86,8 @@ fun ConcentrationTimerScreen(
 
     if (finishTimerDialogVisible) {
         FinishTimerDialog(
+            titleId = R.string.title_finish_concentration,
+            contentId = R.string.content_finish_concentration,
             onConfirmation = {
                 setFinish(true)
                 setFinishTimerDialogVisible(false)
@@ -121,6 +125,7 @@ fun TimerScreenLayout(
     time: Time,
     maxValue: Int,
     timerColor: Color,
+    buttonContent: String,
     onClick: () -> Unit
 ) {
     val timeToSecond =
@@ -161,7 +166,7 @@ fun TimerScreenLayout(
         Spacer(modifier = Modifier.height(100.dp))
 
         CustomTextButton(
-            text = stringResource(R.string.content_button_finish_concentration),
+            text = buttonContent,
             containerColor = PomoroDoTheme.colorScheme.primaryContainer,
             contentColor = Color.White,
             textStyle = PomoroDoTheme.typography.laundryGothicRegular18,
@@ -199,16 +204,21 @@ fun updateTimer(
 }
 
 @Composable
-fun FinishTimerDialog(onConfirmation: () -> Unit, onDismissRequest: () -> Unit) {
+fun FinishTimerDialog(
+    @StringRes titleId: Int,
+    @StringRes contentId: Int,
+    onConfirmation: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
     SimpleAlertDialog(
-        dialogTitleId = R.string.title_finish_concentration,
+        dialogTitleId = titleId,
         confirmTextId = R.string.content_finish,
         dismissTextId = R.string.content_cancel,
         onConfirmation = onConfirmation,
         onDismissRequest = onDismissRequest,
     ) {
         Text(
-            text = stringResource(R.string.content_finish_concentration),
+            text = stringResource(contentId),
             color = PomoroDoTheme.colorScheme.onBackground,
             textAlign = TextAlign.Center,
             style = PomoroDoTheme.typography.laundryGothicRegular14

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/view/ConcentrationTimerSceen.kt
@@ -57,8 +57,6 @@ fun ConcentrationTimerScreen(
     val (finishTimerDialogVisible, setFinishTimerDialogVisible) = remember {
         mutableStateOf(false)
     }
-    var hour by remember { mutableIntStateOf(concentrationTime.hour) }
-    var minute by remember { mutableIntStateOf(concentrationTime.minute) }
     var second by remember { mutableIntStateOf(0) }
     val todoList by timerRunningViewModel.todoList.collectAsState()
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
@@ -1,6 +1,5 @@
 package com.tico.pomorodo.ui.timer.running.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.tico.pomorodo.data.local.datasource.DataSource
@@ -30,19 +29,18 @@ class TimerRunningViewModel @Inject constructor(private val savedStateHandle: Sa
 
     private val _isInitialized: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
-    fun initialConcentrationTime(time: Int) {
+    fun initialConcentrationTime(concentrationTime: Int, breakTime: Int) {
         if (!_isInitialized.value) {
-            _concentrationTime.value = Time(time / 60, time % 60, 0)
-            _timerMaxValue.value = time * 60
+            _concentrationTime.value = Time(concentrationTime / 60, concentrationTime % 60, 0)
+            _breakTime.value = Time(breakTime / 60, breakTime % 60, 0)
+            _timerMaxValue.value = concentrationTime * 60
             _isInitialized.value = true
-            Log.d("initTimerTest", "concentration time: ${_concentrationTime.value}")
         }
     }
 
-    fun initialBreakTime(time: Int) {
+    fun initialBreakTime() {
         if (!_isInitialized.value) {
-            _concentrationTime.value = Time(time / 60, time % 60, 0)
-            _timerMaxValue.value = time * 60
+            _timerMaxValue.value = breakTime.value.hour * 60 * 60 + breakTime.value.minute * 60
             _isInitialized.value = true
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/running/viewmodel/TimerRunningViewModel.kt
@@ -1,5 +1,6 @@
 package com.tico.pomorodo.ui.timer.running.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.tico.pomorodo.data.local.datasource.DataSource
@@ -27,22 +28,31 @@ class TimerRunningViewModel @Inject constructor(private val savedStateHandle: Sa
     private val _oldTodoList: MutableStateFlow<List<TodoData>> = MutableStateFlow(_todoList.value)
     val todoList: StateFlow<List<TodoData>> = _todoList
 
+    private val _isInitialized: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
     fun initialConcentrationTime(time: Int) {
-        _concentrationTime.value = Time(time / 60, time % 60, 0)
-        _timerMaxValue.value = time * 60
+        if (!_isInitialized.value) {
+            _concentrationTime.value = Time(time / 60, time % 60, 0)
+            _timerMaxValue.value = time * 60
+            _isInitialized.value = true
+            Log.d("initTimerTest", "concentration time: ${_concentrationTime.value}")
+        }
     }
 
     fun initialBreakTime(time: Int) {
-        _concentrationTime.value = Time(time / 60, time % 60, 0)
-        _timerMaxValue.value = time * 60
+        if (!_isInitialized.value) {
+            _concentrationTime.value = Time(time / 60, time % 60, 0)
+            _timerMaxValue.value = time * 60
+            _isInitialized.value = true
+        }
     }
 
     fun setConcentrationTime(hour: Int, minute: Int, second: Int? = null) {
         _concentrationTime.value = Time(hour, minute, second)
     }
 
-    fun setBreakTime(hour: Int, minute: Int) {
-        _breakTime.value = Time(hour, minute)
+    fun setBreakTime(hour: Int, minute: Int, second: Int? = null) {
+        _breakTime.value = Time(hour, minute, second)
     }
 
     fun changeTodoState(todoIndex: Int, state: TodoState) {
@@ -59,5 +69,9 @@ class TimerRunningViewModel @Inject constructor(private val savedStateHandle: Sa
 
     fun resetTodoState() {
         _todoList.value = _oldTodoList.value
+    }
+
+    fun setInitializedFlag() {
+        _isInitialized.value = false
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
@@ -91,6 +91,7 @@ fun TimerRootScreen(
             runBlocking {
                 setState(concentrationTimeInMinute, breakTimeInMinute)
                 navigate()
+                timerSetupViewModel.initTimer()
             }
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/view/TimerRootScreen.kt
@@ -36,6 +36,8 @@ fun TimerRootScreen(
     val concentrationTime by timerSetupViewModel.concentrationTime.collectAsState()
     val breakTime by timerSetupViewModel.breakTime.collectAsState()
     val concentrationGoal by timerSetupViewModel.concentrationGoal.collectAsState()
+    val totalConcentrationTime by timerSetupViewModel.totalConcentrationTime.collectAsState()
+    val totalBreakTime by timerSetupViewModel.totalBreakTime.collectAsState()
     val (editConcentrationTimerDialogVisible, setEditConcentrationTimerDialogVisible) = remember {
         mutableStateOf(false)
     }
@@ -57,6 +59,8 @@ fun TimerRootScreen(
             concentrationTime = concentrationTime,
             breakTime = breakTime,
             concentrationGoal = concentrationGoal,
+            totalConcentrationTime = totalConcentrationTime,
+            totalBreakTime = totalBreakTime,
             onConcentrationTimeChange = { time ->
                 timerSetupViewModel.setConcentrationTime(
                     hour = time / 60,
@@ -145,6 +149,8 @@ fun PomodoroTimerScreen(
     concentrationTime: Time,
     breakTime: Time,
     concentrationGoal: Time,
+    totalConcentrationTime: Time,
+    totalBreakTime: Time,
     onConcentrationTimeChange: (Int) -> Unit,
     onBreakTimeChange: (Int) -> Unit,
     isEditTimerDialogVisible: Boolean,
@@ -170,6 +176,8 @@ fun PomodoroTimerScreen(
 
         TodayConcentrationInformation(
             concentrationGoal = concentrationGoal,
+            totalConcentrationTime = totalConcentrationTime,
+            totalBreakTime = totalBreakTime,
             onConcentrationGoalClick = onConcentrationGoalClick
         )
     }
@@ -178,6 +186,8 @@ fun PomodoroTimerScreen(
 @Composable
 fun TodayConcentrationInformation(
     concentrationGoal: Time,
+    totalConcentrationTime: Time,
+    totalBreakTime: Time,
     onConcentrationGoalClick: () -> Unit
 ) {
     Column(
@@ -203,9 +213,9 @@ fun TodayConcentrationInformation(
         ) {
             CustomTimeText(
                 title = stringResource(R.string.title_total_concentration),
-                hour = 10,
-                minute = 0,
-                second = 0,
+                hour = totalConcentrationTime.hour,
+                minute = totalConcentrationTime.minute,
+                second = totalConcentrationTime.second,
                 textColor = PomoroDoTheme.colorScheme.onBackground,
                 spaceDp = 4.dp,
                 titleTextStyle = PomoroDoTheme.typography.laundryGothicRegular18,
@@ -215,9 +225,9 @@ fun TodayConcentrationInformation(
 
             CustomTimeText(
                 title = stringResource(R.string.title_total_break),
-                hour = 3,
-                minute = 0,
-                second = 0,
+                hour = totalBreakTime.hour,
+                minute = totalBreakTime.minute,
+                second = totalBreakTime.second,
                 textColor = PomoroDoTheme.colorScheme.onBackground,
                 spaceDp = 4.dp,
                 titleTextStyle = PomoroDoTheme.typography.laundryGothicRegular18,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
@@ -18,6 +18,12 @@ class TimerSetupViewModel @Inject constructor() : ViewModel() {
     private val _concentrationGoal: MutableStateFlow<Time> = MutableStateFlow(Time(0, 0, 0))
     val concentrationGoal: StateFlow<Time> = _concentrationGoal
 
+    private val _totalConcentrationTime: MutableStateFlow<Time> = MutableStateFlow(Time(0, 0, 0))
+    val totalConcentrationTime: StateFlow<Time> = _totalConcentrationTime
+
+    private val _totalBreakTime: MutableStateFlow<Time> = MutableStateFlow(Time(0, 0, 0))
+    val totalBreakTime: StateFlow<Time> = _totalBreakTime
+
     fun setConcentrationTime(hour: Int, minute: Int, second: Int? = null) {
         _concentrationTime.value = Time(hour, minute, second)
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/timer/setup/viewmodel/TimerSetupViewModel.kt
@@ -29,4 +29,9 @@ class TimerSetupViewModel @Inject constructor() : ViewModel() {
     fun setConcentrationGoal(hour: Int, minute: Int, second: Int) {
         _concentrationGoal.value = Time(hour, minute, second)
     }
+
+    fun initTimer() {
+        _concentrationTime.value = Time(0, 0)
+        _breakTime.value = Time(0, 0)
+    }
 }

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -132,7 +132,6 @@
     <string name="content_break">휴식</string>
 
     // timer - concentration mode
-    <string name="title_concentration_time_left">집중 시간</string>
     <string name="content_button_finish_concentration">집중 종료</string>
     <string name="title_finish_concentration">집중 모드 종료</string>
     <string name="content_finish_concentration">집중 모드를 종료하시겠습니까?</string>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -136,6 +136,9 @@
     <string name="title_finish_concentration">집중 모드 종료</string>
     <string name="content_finish_concentration">집중 모드를 종료하시겠습니까?</string>
     <string name="title_check_todo_list_dialog">할 일 목록</string>
+    <string name="content_button_finish_break">휴식 종료</string>
+    <string name="title_finish_break">휴식 모드 종료</string>
+    <string name="content_finish_break">휴식 모드를 종료하시겠습니까?</string>
 
     // common
     <string name="content_next">다음</string>


### PR DESCRIPTION
### 새로운 내용
- 휴식 시간 화면 구현
- 휴식 시간 화면 연결
- 휴식 시간 종료 시 홈 화면으로 이동하도록 구현
  - 집중, 휴식 타이머 초기화

### 변경된 내용
- 다크모드로 전환할때 타이머가 초기화 되는 문제 해결
- 집중 화면과 휴식 화면이 공통으로 사용하는 내 상수 변경
- home 화면의 총 집중 시간, 총 휴식 시간 상수를 변수로 변경

### 추후 개발 내용
로컬 DB와 연결하면 휴식시간 타이머가 종료되고 데이터를 DB에 작성, Home에서 이를 불러오도록 변경.

Fixes: TICO-59
Related to: TICO-33