### PR TITLE
[FEAT] 구글 로그인 연결 (TICO-133)

### DIFF
--- a/Mobile/PomoroDo/app/build.gradle
+++ b/Mobile/PomoroDo/app/build.gradle
@@ -6,6 +6,14 @@ plugins {
     id 'kotlin-kapt'
 }
 
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withInputStream { stream ->
+        localProperties.load(stream)
+    }
+}
+
 android {
     namespace 'com.tico.pomorodo'
     compileSdk 34
@@ -25,6 +33,10 @@ android {
 
     buildTypes {
         release {
+            defaultConfig {
+                buildConfigField("String", "GOOGLE_AUTH_CLIENT_ID", "\"${localProperties["GOOGLE_AUTH_CLIENT_ID"]}\"")
+                buildConfigField "String", "BASE_URL", "\"${localProperties["BASE_URL"]}\""
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
@@ -38,6 +50,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.8'
@@ -82,6 +95,9 @@ dependencies {
 
     // google login을 위한 credential manager jetpack
     implementation libs.bundles.credential
+
+    // 암호화된 sharedpreference를 사용하기 위한 라이브러리
+    implementation libs.androidx.security
 }
 
 // Allow references to generated code

--- a/Mobile/PomoroDo/app/build.gradle
+++ b/Mobile/PomoroDo/app/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     // 네비게이션 작업을 위한 라이브러리
     implementation libs.androidx.hilt.navigation.compose
+
+    // google login을 위한 credential manager jetpack
+    implementation libs.bundles.credential
 }
 
 // Allow references to generated code

--- a/Mobile/PomoroDo/app/proguard-rules.pro
+++ b/Mobile/PomoroDo/app/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}

--- a/Mobile/PomoroDo/app/src/main/AndroidManifest.xml
+++ b/Mobile/PomoroDo/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -25,6 +29,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/path_provider" />
+        </provider>
     </application>
 
 </manifest>

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/PreferencesManager.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/PreferencesManager.kt
@@ -1,0 +1,45 @@
+package com.tico.pomorodo.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+
+class PreferencesManager(context: Context) {
+
+    private val sharedPreferences: SharedPreferences by lazy {
+
+        val masterKey = MasterKey
+            .Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+
+        EncryptedSharedPreferences.create(
+            context,
+            FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    var editor: SharedPreferences.Editor = sharedPreferences.edit()
+
+    fun saveToken(token: String) {
+        sharedPreferences.edit().putString("auth_token", token).apply()
+    }
+
+    fun getToken(): String? {
+        return sharedPreferences.getString("auth_token", null)
+    }
+
+    fun clearToken() {
+        sharedPreferences.edit().remove("auth_token").apply()
+    }
+
+    companion object {
+        private const val FILE_NAME = "encrypted_perf_file"
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/AuthRepositoryImpl.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.tico.pomorodo.data.repository
+
+import com.tico.pomorodo.data.local.PreferencesManager
+import com.tico.pomorodo.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val preferencesManager: PreferencesManager
+) : AuthRepository {
+
+    override fun saveToken(token: String) {
+        preferencesManager.saveToken(token)
+    }
+
+    override fun getToken(): String? {
+        return preferencesManager.getToken()
+    }
+
+    override fun clearToken() {
+        preferencesManager.clearToken()
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/RepositoryModule.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/RepositoryModule.kt
@@ -1,0 +1,28 @@
+package com.tico.pomorodo.di
+
+import android.content.Context
+import com.tico.pomorodo.data.local.PreferencesManager
+import com.tico.pomorodo.data.repository.AuthRepositoryImpl
+import com.tico.pomorodo.domain.repository.AuthRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RepositoryModule {
+    @Provides
+    @Singleton
+    fun providePreferencesManager(@ApplicationContext context: Context): PreferencesManager {
+        return PreferencesManager(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAuthRepository(preferencesManager: PreferencesManager): AuthRepository {
+        return AuthRepositoryImpl(preferencesManager)
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
@@ -1,0 +1,29 @@
+package com.tico.pomorodo.di
+
+import com.tico.pomorodo.domain.repository.AuthRepository
+import com.tico.pomorodo.domain.usecase.ClearTokenUseCase
+import com.tico.pomorodo.domain.usecase.GetTokenUseCase
+import com.tico.pomorodo.domain.usecase.SaveTokenUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+    @Provides
+    fun provideSaveTokenUseCase(authRepository: AuthRepository): SaveTokenUseCase {
+        return SaveTokenUseCase(authRepository)
+    }
+
+    @Provides
+    fun provideGetTokenUseCase(authRepository: AuthRepository): GetTokenUseCase {
+        return GetTokenUseCase(authRepository)
+    }
+
+    @Provides
+    fun provideClearTokenUseCase(authRepository: AuthRepository): ClearTokenUseCase {
+        return ClearTokenUseCase(authRepository)
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/AuthRepository.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/AuthRepository.kt
@@ -1,0 +1,7 @@
+package com.tico.pomorodo.domain.repository
+
+interface AuthRepository {
+    fun saveToken(token: String)
+    fun getToken(): String?
+    fun clearToken()
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/ClearTokenUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/ClearTokenUseCase.kt
@@ -1,0 +1,14 @@
+package com.tico.pomorodo.domain.usecase
+
+import com.tico.pomorodo.domain.repository.AuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class ClearTokenUseCase @Inject constructor(private val authRepository: AuthRepository) {
+
+    suspend operator fun invoke() =
+        withContext(Dispatchers.IO) {
+            authRepository.clearToken()
+        }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/GetTokenUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/GetTokenUseCase.kt
@@ -1,0 +1,14 @@
+package com.tico.pomorodo.domain.usecase
+
+import com.tico.pomorodo.domain.repository.AuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetTokenUseCase @Inject constructor(private val authRepository: AuthRepository) {
+
+    suspend operator fun invoke(): String? =
+        withContext(Dispatchers.IO) {
+        authRepository.getToken()
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/SaveTokenUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/SaveTokenUseCase.kt
@@ -1,0 +1,14 @@
+package com.tico.pomorodo.domain.usecase
+
+import com.tico.pomorodo.domain.repository.AuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class SaveTokenUseCase @Inject constructor(private val authRepository: AuthRepository) {
+
+    suspend operator fun invoke(token: String) =
+        withContext(Dispatchers.IO) {
+            authRepository.saveToken(token)
+        }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -3,10 +3,11 @@ package com.tico.pomorodo.navigation
 import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.tico.pomorodo.ui.auth.view.LogInScreen
-import com.tico.pomorodo.ui.auth.view.SignUpScreen
+import com.tico.pomorodo.ui.auth.view.SignUpRoute
 import com.tico.pomorodo.ui.home.view.HomeScreen
 import com.tico.pomorodo.ui.home.view.MyInfoScreen
 import com.tico.pomorodo.ui.home.view.TodoScreen
@@ -71,9 +72,15 @@ fun NavGraphBuilder.logInScreen(navigate: () -> Unit) {
     }
 }
 
-fun NavGraphBuilder.signUpScreen(navigate: () -> Unit) {
-    composable(route = MainNavigationDestination.SignUp.name) {
-        SignUpScreen(navigate = navigate)
+fun NavGraphBuilder.signUpScreen(navController: NavHostController, navigate: () -> Unit) {
+    composable(route = MainNavigationDestination.SignUp.name) { navBackStackEntry ->
+        val authNavBackStackEntry = remember(navBackStackEntry) {
+            navController.getBackStackEntry(MainNavigationDestination.LogIn.name)
+        }
+        SignUpRoute(
+            navBackStackEntry = authNavBackStackEntry,
+            navigate = navigate
+        )
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -44,7 +44,10 @@ fun MainScreen() {
             ) {
                 splashScreen(navigate = mainNavController::navigateToLogIn)
                 logInScreen(navigate = mainNavController::navigateToSignUp)
-                signUpScreen(navigate = mainNavController::navigateToHome)
+                signUpScreen(
+                    navController = mainNavController,
+                    navigate = mainNavController::navigateToHome
+                )
                 homeScreen(
                     setTimerState = { concentrationTime, breakTime ->
                         mainNavController.setState(CONCENTRATION_TIME, concentrationTime)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
@@ -223,7 +223,7 @@ private suspend fun handleCredentialFailure(
                 GetCredentialRequest.Builder()
                     .addCredentialOption(signInWithGoogleOption)
                     .build()
-            Log.d(TAG, "handleCredentialFailure: NoCredentialException")
+            Log.e(TAG, "handleCredentialFailure: NoCredentialException")
             handleLogin(
                 context = context,
                 request = signInWithGoogleRequest,
@@ -254,22 +254,7 @@ fun handleSignIn(result: GetCredentialResponse): GoogleIdTokenCredential {
     when (val credential = result.credential) {
         is CustomCredential -> {
             if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                val googleIdTokenCredential =
-                    GoogleIdTokenCredential.createFrom(credential.data)
-
-                val googleIdToken = googleIdTokenCredential.idToken
-
-                Log.i(TAG, "googleIdToken: $googleIdToken")
-                Log.i(TAG, "id: ${googleIdTokenCredential.id}")
-                Log.i(TAG, "type: ${googleIdTokenCredential.type}")
-                Log.i(TAG, "data: ${googleIdTokenCredential.data}")
-                Log.i(TAG, "givenName: ${googleIdTokenCredential.givenName}")
-                Log.i(TAG, "displayName: ${googleIdTokenCredential.displayName}")
-                Log.i(TAG, "familyName: ${googleIdTokenCredential.familyName}")
-                Log.i(TAG, "phoneNumber: ${googleIdTokenCredential.phoneNumber}")
-                Log.i(TAG, "profilePictureUri: ${googleIdTokenCredential.profilePictureUri}")
-
-                return googleIdTokenCredential
+                return GoogleIdTokenCredential.createFrom(credential.data)
             } else {
                 throw UnexpectedException("Unexpected type of credential")
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
@@ -1,5 +1,7 @@
 package com.tico.pomorodo.ui.auth.view
 
+import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,20 +21,62 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import com.tico.pomorodo.BuildConfig
 import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.auth.viewModel.AuthViewModel
+import com.tico.pomorodo.ui.common.view.CustomTextButton
+import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcLogoGoogle
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcTitle
 import com.tico.pomorodo.ui.theme.IconPack
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
+import kotlinx.coroutines.launch
+import java.security.MessageDigest
+import java.util.UUID
+
+private const val TAG = "LoginScreen: "
 
 @Composable
-fun LogInScreen(navigate: () -> Unit) {
+fun LogInScreen(
+    viewModel: AuthViewModel = hiltViewModel(),
+    navigate: () -> Unit,
+    isOffline: Boolean = false
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val hashedNonce = generateNonce()
+    val googleIdOption: GetGoogleIdOption = GetGoogleIdOption.Builder()
+        .setFilterByAuthorizedAccounts(false)
+        .setServerClientId(BuildConfig.GOOGLE_AUTH_CLIENT_ID)
+        .setAutoSelectEnabled(true)
+        .setNonce(hashedNonce)
+        .build()
+
+    val request: GetCredentialRequest = GetCredentialRequest.Builder()
+        .addCredentialOption(googleIdOption)
+        .build()
+
     Surface(modifier = Modifier.fillMaxSize(), color = PomoroDoTheme.colorScheme.surface) {
         Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
             Icon(
@@ -50,30 +94,63 @@ fun LogInScreen(navigate: () -> Unit) {
                     .padding(horizontal = 57.dp),
                 contentAlignment = Alignment.Center
             ) {
-                LogInButton(onClick = navigate)
+                if (isOffline) {
+                    OfflineLogInButton(onClick = { navigate() })
+                } else {
+                    LogInButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                handleLogin(
+                                    context = context,
+                                    request = request,
+                                    nonce = hashedNonce,
+                                    onSuccess = { result ->
+                                        viewModel.requestLogin()
+                                        viewModel.setProfile(result.profilePictureUri)
+                                        navigate()
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
+fun OfflineLogInButton(onClick: () -> Unit) {
+    CustomTextButton(
+        text = stringResource(id = R.string.content_offline_log_in),
+        containerColor = PomoroDoTheme.colorScheme.background,
+        contentColor = PomoroDoTheme.colorScheme.primaryContainer,
+        textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
+        verticalPadding = 10.dp,
+        borderColor = PomoroDoTheme.colorScheme.primaryContainer,
+        borderWidth = 1.5.dp,
+        onClick = onClick
+    )
+}
+
+@Composable
 fun LogInButton(onClick: () -> Unit) {
     Button(
-        onClick = { onClick() },
+        onClick = onClick,
         modifier = Modifier
             .border(
                 width = 1.dp,
-                color = Color(0xFF747775),
+                color = PomoroDoTheme.colorScheme.gray70,
                 shape = RoundedCornerShape(4.dp)
             )
             .height(40.dp)
             .fillMaxWidth(),
         shape = RoundedCornerShape(4.dp),
         colors = ButtonColors(
-            containerColor = Color.White,
-            contentColor = Color(0xFF1F1F1F),
-            disabledContainerColor = Color.White,
-            disabledContentColor = Color(0xFF1F1F1F)
+            containerColor = PomoroDoTheme.colorScheme.background,
+            contentColor = PomoroDoTheme.colorScheme.googleLoginText,
+            disabledContainerColor = PomoroDoTheme.colorScheme.background,
+            disabledContentColor = PomoroDoTheme.colorScheme.googleLoginText
         ),
         contentPadding = PaddingValues(horizontal = 8.dp)
     ) {
@@ -90,10 +167,118 @@ fun LogInButton(onClick: () -> Unit) {
             )
             Text(
                 text = stringResource(R.string.content_log_in_with_google),
-                color = Color(0xFF1F1F1F),
                 textAlign = TextAlign.Start,
                 style = PomoroDoTheme.typography.robotoMedium14
             )
         }
     }
 }
+
+private suspend fun handleLogin(
+    context: Context,
+    request: GetCredentialRequest,
+    nonce: String,
+    onSuccess: (GoogleIdTokenCredential) -> Unit
+) {
+    val credentialManager = CredentialManager.create(context = context)
+
+    runCatching {
+        val result = credentialManager.getCredential(
+            request = request,
+            context = context,
+        )
+        Log.d(TAG, "requestGoogleLogin: runCatching")
+        handleSignIn(result)
+    }.onSuccess { result ->
+        Log.d(TAG, "requestGoogleLogin: Success login!!")
+        onSuccess(result)
+    }.onFailure {
+        Log.e(TAG, "requestGoogleLogin: onFailure")
+        handleCredentialFailure(it, nonce, context, onSuccess)
+    }
+}
+
+private fun generateNonce(): String {
+    val ranNonce = UUID.randomUUID().toString()
+    val bytes = ranNonce.toByteArray()
+    val md = MessageDigest.getInstance("SHA-256")
+    val digest = md.digest(bytes)
+    return digest.fold("") { str, it -> str + "%02x".format(it) }
+}
+
+private suspend fun handleCredentialFailure(
+    it: Throwable,
+    nonce: String,
+    context: Context,
+    onSuccess: (GoogleIdTokenCredential) -> Unit
+) {
+    when (it) {
+        is NoCredentialException -> {
+            val signInWithGoogleOption: GetSignInWithGoogleOption =
+                GetSignInWithGoogleOption.Builder(BuildConfig.GOOGLE_AUTH_CLIENT_ID)
+                    .setNonce(nonce)
+                    .build()
+
+            val signInWithGoogleRequest: GetCredentialRequest =
+                GetCredentialRequest.Builder()
+                    .addCredentialOption(signInWithGoogleOption)
+                    .build()
+            Log.d(TAG, "handleCredentialFailure: NoCredentialException")
+            handleLogin(
+                context = context,
+                request = signInWithGoogleRequest,
+                nonce = nonce,
+                onSuccess = onSuccess
+            )
+        }
+
+        is GoogleIdTokenParsingException -> {
+            Log.e(TAG, "Received an invalid google id token response", it)
+        }
+
+        is GetCredentialCancellationException -> {
+            Log.e(TAG, "signInWithGoogleRequest: $it")
+        }
+
+        is GetCredentialProviderConfigurationException -> {
+            context.executeToast(R.string.content_please_update_google_play_service)
+        }
+
+        else -> {
+            Log.e(TAG, "signInWithPasskeyRequest: $it")
+        }
+    }
+}
+
+fun handleSignIn(result: GetCredentialResponse): GoogleIdTokenCredential {
+    when (val credential = result.credential) {
+        is CustomCredential -> {
+            if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                val googleIdTokenCredential =
+                    GoogleIdTokenCredential.createFrom(credential.data)
+
+                val googleIdToken = googleIdTokenCredential.idToken
+
+                Log.i(TAG, "googleIdToken: $googleIdToken")
+                Log.i(TAG, "id: ${googleIdTokenCredential.id}")
+                Log.i(TAG, "type: ${googleIdTokenCredential.type}")
+                Log.i(TAG, "data: ${googleIdTokenCredential.data}")
+                Log.i(TAG, "givenName: ${googleIdTokenCredential.givenName}")
+                Log.i(TAG, "displayName: ${googleIdTokenCredential.displayName}")
+                Log.i(TAG, "familyName: ${googleIdTokenCredential.familyName}")
+                Log.i(TAG, "phoneNumber: ${googleIdTokenCredential.phoneNumber}")
+                Log.i(TAG, "profilePictureUri: ${googleIdTokenCredential.profilePictureUri}")
+
+                return googleIdTokenCredential
+            } else {
+                throw UnexpectedException("Unexpected type of credential")
+            }
+        }
+
+        else -> {
+            throw UnexpectedException("Unexpected type of credential")
+        }
+    }
+}
+
+class UnexpectedException(message: String) : Exception(message)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/LogInScreen.kt
@@ -105,6 +105,7 @@ fun LogInScreen(
                                     request = request,
                                     nonce = hashedNonce,
                                     onSuccess = { result ->
+                                        viewModel.saveIdToken(result.idToken)
                                         viewModel.requestLogin()
                                         viewModel.setProfile(result.profilePictureUri)
                                         navigate()

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/PhotoChooseDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/PhotoChooseDialog.kt
@@ -1,0 +1,90 @@
+package com.tico.pomorodo.ui.auth.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.common.view.SimpleText
+import com.tico.pomorodo.ui.common.view.clickableWithRipple
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun PhotoChooseDialog(
+    isDefaultImage: Boolean,
+    onDismissRequest: () -> Unit,
+    onTakePhotoClicked: () -> Unit,
+    onPickPhotoClicked: () -> Unit,
+    onApplyDefaultImageClicked: () -> Unit
+) {
+    val colors = CardDefaults.cardColors(containerColor = PomoroDoTheme.colorScheme.dialogSurface)
+    Dialog(
+        onDismissRequest = { onDismissRequest() },
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Card(
+            modifier = Modifier.padding(horizontal = 40.dp),
+            shape = RoundedCornerShape(15.dp),
+            colors = colors,
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SimpleText(
+                    modifier = Modifier
+                        .padding(vertical = 9.dp, horizontal = 10.dp)
+                        .fillMaxWidth(),
+                    textId = R.string.title_profile_photo_setting,
+                    textAlign = TextAlign.Start,
+                    style = PomoroDoTheme.typography.laundryGothicBold20,
+                    color = PomoroDoTheme.colorScheme.onBackground,
+                )
+                SimpleText(
+                    modifier = Modifier
+                        .clickableWithRipple(10.dp, true) { onTakePhotoClicked() }
+                        .padding(vertical = 9.dp, horizontal = 10.dp)
+                        .fillMaxWidth(),
+                    textId = R.string.content_take_photo,
+                    textAlign = TextAlign.Start,
+                    style = PomoroDoTheme.typography.laundryGothicRegular16,
+                    color = PomoroDoTheme.colorScheme.onBackground,
+                )
+                SimpleText(
+                    modifier = Modifier
+                        .clickableWithRipple(10.dp, true) { onPickPhotoClicked() }
+                        .padding(vertical = 9.dp, horizontal = 10.dp)
+                        .fillMaxWidth(),
+                    textId = R.string.content_pick_photo,
+                    textAlign = TextAlign.Start,
+                    style = PomoroDoTheme.typography.laundryGothicRegular16,
+                    color = PomoroDoTheme.colorScheme.onBackground,
+                )
+                if (!isDefaultImage) {
+                    SimpleText(
+                        modifier = Modifier
+                            .clickableWithRipple(10.dp, true) { onApplyDefaultImageClicked() }
+                            .fillMaxWidth()
+                            .padding(vertical = 9.dp, horizontal = 10.dp),
+                        textId = R.string.content_default_image,
+                        textAlign = TextAlign.Start,
+                        style = PomoroDoTheme.typography.laundryGothicRegular16,
+                        color = PomoroDoTheme.colorScheme.onBackground,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/view/SignUpScreen.kt
@@ -1,6 +1,11 @@
 package com.tico.pomorodo.ui.auth.view
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -23,40 +28,158 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
+import com.tico.pomorodo.BuildConfig
 import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.auth.viewModel.AuthViewModel
 import com.tico.pomorodo.ui.common.view.CustomTextButton
+import com.tico.pomorodo.ui.common.view.createImageFile
+import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.iconpack.commonIconPack.IcProfileDefault
 import com.tico.pomorodo.ui.theme.IconPack
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import com.tico.pomorodo.ui.theme.laundryGothic
+import java.util.Objects
+
 
 @Composable
-fun SignUpScreen(navigate: () -> Unit) {
-    val text = rememberSaveable { mutableStateOf("") }
-    val enable = text.value.isNotBlank()
+fun SignUpRoute(
+    navBackStackEntry: NavBackStackEntry,
+    viewModel: AuthViewModel = hiltViewModel(navBackStackEntry),
+    navigate: () -> Unit
+) {
+    val context = LocalContext.current
+    val inputText by viewModel.name.collectAsState()
+    val profile by viewModel.profile.collectAsState()
+    val enable = inputText.isNotBlank()
+    var showPhotoChooseDialog by rememberSaveable {
+        mutableStateOf(false)
+    }
+    var file = context.createImageFile()
+    var uri = FileProvider.getUriForFile(
+        Objects.requireNonNull(context),
+        BuildConfig.APPLICATION_ID + ".provider", file
+    )
+    var grantCameraState by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val pickPhotoLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { pickUri ->
+            if (pickUri != null) {
+                viewModel.setProfile(pickUri)
+            }
+        }
+    val takePhotoCameraLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { isSuccess ->
+            if (isSuccess) {
+                viewModel.setProfile(uri)
+                file = context.createImageFile()
+                uri = FileProvider.getUriForFile(
+                    Objects.requireNonNull(context),
+                    BuildConfig.APPLICATION_ID + ".provider", file
+                )
+            } else {
+                context.executeToast(messageId = R.string.content_try_one_more)
+            }
+        }
 
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        grantCameraState = granted
+        if (granted) {
+            takePhotoCameraLauncher.launch(uri)
+        } else {
+            context.executeToast(messageId = R.string.content_please_permission)
+        }
+    }
+
+    Surface(color = PomoroDoTheme.colorScheme.background) {
+        Column(
+            modifier = Modifier,
+        ) {
+            if (showPhotoChooseDialog) {
+                PhotoChooseDialog(
+                    isDefaultImage = profile == null,
+                    onDismissRequest = { showPhotoChooseDialog = false },
+                    onTakePhotoClicked = {
+                        if (grantCameraState) {
+                            takePhotoCameraLauncher.launch(uri)
+                        } else {
+                            permissionLauncher.launch(Manifest.permission.CAMERA)
+                        }
+                        showPhotoChooseDialog = false
+                    },
+                    onPickPhotoClicked = {
+                        pickPhotoLauncher.launch(
+                            PickVisualMediaRequest(
+                                ActivityResultContracts.PickVisualMedia.ImageOnly
+                            )
+                        )
+                        showPhotoChooseDialog = false
+                    },
+                    onApplyDefaultImageClicked = {
+                        viewModel.setProfile(null)
+                        showPhotoChooseDialog = false
+                    }
+                )
+            }
+            SignUpScreen(
+                profileUri = profile,
+                onProfileClicked = { showPhotoChooseDialog = true },
+                inputText = inputText,
+                onInputTextChanged = viewModel::setName,
+                enable = enable,
+                onSignUpButtonClicked = navigate
+            )
+        }
+    }
+}
+
+@Composable
+fun SignUpScreen(
+    profileUri: Uri?,
+    onProfileClicked: () -> Unit,
+    inputText: String,
+    onInputTextChanged: (String) -> Unit,
+    enable: Boolean,
+    onSignUpButtonClicked: () -> Unit
+) {
     Column(
         modifier = Modifier.padding(horizontal = 30.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.Top,
@@ -68,31 +191,34 @@ fun SignUpScreen(navigate: () -> Unit) {
             style = PomoroDoTheme.typography.laundryGothicBold20
         )
         Spacer(modifier = Modifier.height(20.dp))
-        IconDefaultProfile()
+        IconDefaultProfile(
+            profileUri = profileUri,
+            onProfileClicked = onProfileClicked
+        )
         Spacer(modifier = Modifier.height(18.dp))
-        ProfileEditText(text)
+        ProfileEditText(inputText = inputText, onInputTextChanged = onInputTextChanged)
         Spacer(modifier = Modifier.height(20.dp))
         CustomTextButton(
             text = stringResource(id = R.string.content_button_sign_up),
             enabled = enable,
             containerColor = PomoroDoTheme.colorScheme.primaryContainer,
-            contentColor = PomoroDoTheme.colorScheme.background,
+            contentColor = Color.White,
             disabledContainerColor = PomoroDoTheme.colorScheme.gray70,
             disabledContentColor = PomoroDoTheme.colorScheme.background,
             textStyle = PomoroDoTheme.typography.laundryGothicRegular18,
             verticalPadding = 12.dp,
-            onClick = navigate
+            onClick = onSignUpButtonClicked
         )
     }
 }
 
 @Composable
-fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
+fun IconDefaultProfile(profileUri: Uri? = null, onProfileClicked: () -> Unit) {
     Box(modifier = Modifier
         .size(110.dp)
         .clip(shape = CircleShape)
-        .clickable { /*TODO*/ }) {
-        if (defaultProfileUri == null) {
+        .clickable { onProfileClicked() }) {
+        if (profileUri == null) {
             Icon(
                 imageVector = IconPack.IcProfileDefault,
                 contentDescription = stringResource(R.string.content_ic_profile_default),
@@ -100,7 +226,7 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
             )
         } else {
             GlideImage(
-                imageModel = { defaultProfileUri },
+                imageModel = { profileUri },
                 requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.AUTOMATIC) },
                 imageOptions = ImageOptions(
                     contentScale = ContentScale.Crop,
@@ -126,26 +252,36 @@ fun IconDefaultProfile(defaultProfileUri: Uri? = null) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileEditText(text: MutableState<String>) {
+fun ProfileEditText(inputText: String, onInputTextChanged: (String) -> Unit) {
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
+    val colors = TextFieldDefaults.colors(
+        focusedContainerColor = PomoroDoTheme.colorScheme.background,
+        unfocusedContainerColor = PomoroDoTheme.colorScheme.background,
+        focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
+        focusedLabelColor = PomoroDoTheme.colorScheme.primaryContainer,
+        focusedTextColor = PomoroDoTheme.colorScheme.onBackground,
+        unfocusedTextColor = PomoroDoTheme.colorScheme.onBackground,
+        cursorColor = PomoroDoTheme.colorScheme.primaryContainer
+    )
 
     BasicTextField(
-        value = text.value,
-        onValueChange = { text.value = it },
+        value = inputText,
+        onValueChange = { onInputTextChanged(it) },
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 0.dp),
-        textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
+        textStyle = PomoroDoTheme.typography.laundryGothicRegular16.copy(color = colors.unfocusedTextColor),
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
             imeAction = ImeAction.Done
         ),
         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-        interactionSource = interactionSource
+        interactionSource = interactionSource,
+        cursorBrush = SolidColor(colors.cursorColor)
     ) { innerTextField ->
         TextFieldDefaults.DecorationBox(
-            value = text.value,
+            value = inputText,
             innerTextField = innerTextField,
             enabled = true,
             singleLine = true,
@@ -166,12 +302,15 @@ fun ProfileEditText(text: MutableState<String>) {
                 )
             },
             shape = RoundedCornerShape(size = 5.dp),
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = PomoroDoTheme.colorScheme.background,
-                unfocusedContainerColor = PomoroDoTheme.colorScheme.background,
-                focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
-                focusedLabelColor = PomoroDoTheme.colorScheme.primaryContainer
-            ),
+            colors = colors,
+            container = {
+                TextFieldDefaults.Container(
+                    enabled = true,
+                    isError = false,
+                    interactionSource = interactionSource,
+                    colors = colors,
+                )
+            },
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 14.dp)
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthViewModel.kt
@@ -1,0 +1,34 @@
+package com.tico.pomorodo.ui.auth.viewModel
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+) : ViewModel() {
+
+    private var _name = MutableStateFlow<String>("")
+    val name: StateFlow<String>
+        get() = _name.asStateFlow()
+
+    private var _profile = MutableStateFlow<Uri?>(null)
+    val profile: StateFlow<Uri?>
+        get() = _profile.asStateFlow()
+
+    fun setName(inputText: String) {
+        _name.value = inputText
+    }
+
+    fun setProfile(url: Uri?) {
+        _profile.value = url
+    }
+
+    fun requestLogin() {
+
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthViewModel.kt
@@ -2,14 +2,22 @@ package com.tico.pomorodo.ui.auth.viewModel
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tico.pomorodo.domain.usecase.ClearTokenUseCase
+import com.tico.pomorodo.domain.usecase.GetTokenUseCase
+import com.tico.pomorodo.domain.usecase.SaveTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
+    private val saveTokenUseCase: SaveTokenUseCase,
+    private val getTokenUseCase: GetTokenUseCase,
+    private val clearTokenUseCase: ClearTokenUseCase
 ) : ViewModel() {
 
     private var _name = MutableStateFlow<String>("")
@@ -20,6 +28,9 @@ class AuthViewModel @Inject constructor(
     val profile: StateFlow<Uri?>
         get() = _profile.asStateFlow()
 
+    private var authToken = MutableStateFlow<String?>(null)
+
+    private var googleIdToken = MutableStateFlow<String?>(null)
     fun setName(inputText: String) {
         _name.value = inputText
     }
@@ -28,7 +39,29 @@ class AuthViewModel @Inject constructor(
         _profile.value = url
     }
 
-    fun requestLogin() {
+    fun saveIdToken(idToken: String) {
+        googleIdToken.value = idToken
+    }
 
+    fun requestLogin() {
+    }
+
+    fun saveToken(token: String) {
+        viewModelScope.launch {
+            saveTokenUseCase(token)
+        }
+    }
+
+    fun getToken() {
+        viewModelScope.launch {
+            authToken.value = getTokenUseCase()
+        }
+    }
+
+    fun clearToken() {
+        viewModelScope.launch {
+            clearTokenUseCase()
+            authToken.value = null
+        }
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/AddCategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/AddCategoryScreen.kt
@@ -109,7 +109,8 @@ fun AddCategoryScreen(
                     )
                 },
                 singleLine = true,
-                colors = textFieldColors
+                colors = textFieldColors,
+                textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
             )
             CategoryType(type = type, colors = radioButtonColors, onTypeChanged = onTypeChanged)
             HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupDeleteDialogs.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupDeleteDialogs.kt
@@ -103,7 +103,8 @@ fun GroupDeleteSecondDialog(
                             onClickedListener = { onValueChange("") }
                         )
                     }
-                }
+                },
+                textStyle = PomoroDoTheme.typography.laundryGothicRegular14
             )
         },
         onConfirmation = onConfirmation,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupMemberChooseScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupMemberChooseScreen.kt
@@ -198,7 +198,8 @@ fun GroupMemberChooseScreen(
                         onClickedListener = { onSearchNameChanged("") }
                     )
                 }
-            }
+            },
+            textStyle = PomoroDoTheme.typography.laundryGothicRegular14
         )
         Spacer(modifier = Modifier.height(16.dp))
         if (filteredList.isEmpty()) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
@@ -222,7 +222,8 @@ fun InfoCategoryScreen(
                     )
                 },
                 singleLine = true,
-                colors = textFieldColors
+                colors = textFieldColors,
+                textStyle = PomoroDoTheme.typography.laundryGothicRegular14
             )
             CategoryType(type)
             HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomButton.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomButton.kt
@@ -22,6 +22,7 @@ fun CustomTextButton(
     text: String,
     enabled: Boolean = true,
     borderColor: Color = Color.Unspecified,
+    borderWidth: Dp = 1.dp,
     containerColor: Color,
     contentColor: Color,
     disabledContainerColor: Color = PomoroDoTheme.colorScheme.gray70,
@@ -34,7 +35,7 @@ fun CustomTextButton(
         modifier = modifier
             .clickableWithRipple(10.dp, enabled) { onClick() }
             .background(if (enabled) containerColor else disabledContainerColor)
-            .border(1.dp, borderColor, RoundedCornerShape(10.dp))
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
             .fillMaxWidth()
             .padding(vertical = verticalPadding)
     ) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomTextField.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomTextField.kt
@@ -13,7 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -23,6 +25,7 @@ import androidx.compose.ui.unit.dp
 fun CustomTextField(
     modifier: Modifier = Modifier,
     value: String,
+    textStyle: TextStyle,
     onValueChange: (String) -> Unit,
     callback: (() -> Unit)? = null,
     enabled: Boolean = true,
@@ -59,7 +62,9 @@ fun CustomTextField(
                 keyboardController?.hide()
             },
         ),
-        singleLine = singleLine
+        singleLine = singleLine,
+        textStyle = textStyle.copy(color = colors.unfocusedTextColor),
+        cursorBrush = SolidColor(colors.cursorColor)
     ) { innerTextField ->
         TextFieldDefaults.DecorationBox(
             value = value,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Extensions.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Extensions.kt
@@ -1,5 +1,8 @@
 package com.tico.pomorodo.ui.common.view
 
+import android.content.Context
+import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -14,8 +17,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import com.tico.pomorodo.data.model.SelectedUser
 import com.tico.pomorodo.data.model.User
+import java.io.File
+import java.text.SimpleDateFormat
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Date
 import java.util.Locale
 
 fun Modifier.addFocusCleaner(focusManager: FocusManager, doOnClear: () -> Unit = {}): Modifier {
@@ -84,3 +90,18 @@ fun Modifier.clickableWithRipple(
 )
 
 fun LocalDateTime.getTimeFormat(): String = format(DateTimeFormatter.ofPattern("a h:mm", Locale.US))
+
+fun Context.createImageFile(): File {
+    val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss").format(Date())
+    val imageFileName = "Profile_Image_$timeStamp"
+    val image = File.createTempFile(
+        imageFileName,
+        ".jpg",
+        externalCacheDir
+    )
+    return image
+}
+
+fun Context.executeToast(@StringRes messageId: Int) {
+    Toast.makeText(this, this.getString(messageId), Toast.LENGTH_SHORT).show()
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/Color.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/Color.kt
@@ -342,6 +342,8 @@ val gray50 = Color(0xFFB4B4B4)
 val gray30 = Color(0xFF898989)
 val gray20 = Color(0xFF5C5C5C)
 val gray10 = Color(0xFF474747)
+val googleLoginTextLight = Color(0xFF1F1F1F)
+val googleLoginTextDark = Color(0xFFE3E3E3)
 
 internal val LightColorScheme = PomoroDoColorScheme(
     primary = primaryLight,
@@ -395,7 +397,8 @@ internal val LightColorScheme = PomoroDoColorScheme(
     error50 = palettesError50,
     timerBackgroundColor = onPrimaryLight,
     breakTimeColor = secondaryContainerLight,
-    modeBackgroundColor = palettesNeutral20
+    modeBackgroundColor = palettesNeutral20,
+    googleLoginText = googleLoginTextLight
 )
 
 internal val DarkColorScheme = PomoroDoColorScheme(
@@ -450,7 +453,8 @@ internal val DarkColorScheme = PomoroDoColorScheme(
     error50 = palettesError50,
     timerBackgroundColor = gray20,
     breakTimeColor = secondaryDark,
-    modeBackgroundColor = backgroundDark
+    modeBackgroundColor = backgroundDark,
+    googleLoginText = googleLoginTextDark
 )
 
 @Immutable
@@ -507,6 +511,7 @@ data class PomoroDoColorScheme(
     val timerBackgroundColor: Color,
     val breakTimeColor: Color,
     val modeBackgroundColor: Color,
+    val googleLoginText: Color,
 )
 
 val LocalPomoroDoColorScheme = staticCompositionLocalOf {
@@ -562,6 +567,7 @@ val LocalPomoroDoColorScheme = staticCompositionLocalOf {
         error50 = Color.Unspecified,
         timerBackgroundColor = Color.Unspecified,
         breakTimeColor = Color.Unspecified,
-        modeBackgroundColor = Color.Unspecified
+        modeBackgroundColor = Color.Unspecified,
+        googleLoginText = Color.Unspecified
     )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
@@ -137,7 +137,7 @@ fun TodoMake(
     onValueChange: (String) -> Unit,
 ) {
     val textFieldColors = TextFieldDefaults.colors(
-        focusedTextColor = PomoroDoTheme.colorScheme.onBackground,
+        focusedTextColor = PomoroDoTheme.colorScheme.background,
         unfocusedTextColor = PomoroDoTheme.colorScheme.onBackground,
         disabledTextColor = PomoroDoTheme.colorScheme.gray10,
         errorTextColor = PomoroDoTheme.colorScheme.error50,
@@ -145,7 +145,7 @@ fun TodoMake(
         unfocusedContainerColor = Color.Transparent,
         cursorColor = PomoroDoTheme.colorScheme.primaryContainer,
         unfocusedIndicatorColor = PomoroDoTheme.colorScheme.onBackground,
-        focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer
+        focusedIndicatorColor = PomoroDoTheme.colorScheme.primaryContainer,
     )
     Row(
         horizontalArrangement = Arrangement.spacedBy(5.dp),
@@ -161,6 +161,7 @@ fun TodoMake(
             modifier = Modifier.weight(1f),
             value = inputText,
             onValueChange = onValueChange,
+            textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
             placeholder = {
                 SimpleText(
                     text = stringResource(id = R.string.content_todo_placehold),

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     // log in
     <string name="content_ic_logo_google">logo of google</string>
     <string name="content_log_in_with_google">Log in with Google</string>
+    <string name="content_offline_log_in">오프라인 모드</string>
 
     // sign up
     <string name="title_sign_up">회원 정보 입력</string>
@@ -14,6 +15,13 @@
     <string name="content_user_name_label">닉네임</string>
     <string name="content_user_name_placeholder">닉네임을 입력해주세요.</string>
     <string name="content_button_sign_up">가입</string>
+    <string name="title_profile_photo_setting">프로필 사진 설정</string>
+    <string name="content_pick_photo">앨범에서 사진 선택</string>
+    <string name="content_default_image">기본 이미지 적용</string>
+    <string name="content_take_photo">사진 촬영</string>
+    <string name="content_try_one_more">다시 한 번 시도해 주세요.</string>
+    <string name="content_please_permission">권한을 허용해 주세요.</string>
+    <string name="content_please_update_google_play_service">"google play service를 업데이트 해주세요."</string>
 
     // pomodoro timer
     <string name="content_ic_timer_pin">타이머의 중심 아이콘</string>

--- a/Mobile/PomoroDo/app/src/main/res/xml/path_provider.xml
+++ b/Mobile/PomoroDo/app/src/main/res/xml/path_provider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-cache-path name="my_images" path="/"/>
+</paths>

--- a/Mobile/PomoroDo/gradle/libs.versions.toml
+++ b/Mobile/PomoroDo/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlin-serialization-json = "1.5.1"
 kotlin-serealization-converter = "1.0.0"
 okhttp3 = "4.11.0"
 # 종속성주입을 위한 라이브러리
-hilt = "2.44"
+hilt = "2.46"
 # material3 최신 버전 적용을 위한 라이브러리
 material3 = "1.3.0-beta04"
 material3-navigation = "1.3.0-beta02"

--- a/Mobile/PomoroDo/gradle/libs.versions.toml
+++ b/Mobile/PomoroDo/gradle/libs.versions.toml
@@ -27,6 +27,9 @@ compose-wheel-picker = "1.0.0-beta05"
 # navigation 작업을 위한 라이브러리
 android-navigation = "2.8.0-beta02"
 hilt-navigation-compose = "1.2.0"
+# google login을 위한 credential manager jetpack
+androidx-credential = "1.2.2"
+identity-googleid = "1.1.1"
 
 
 [libraries]
@@ -64,6 +67,10 @@ compose-wheel-picker = { group = "com.github.zj565061763", name = "compose-wheel
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "android-navigation" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 
+# google login을 위한 credential manager jetpack
+androidx-credential = { group = "androidx.credentials", name = "credentials", version.ref = "androidx-credential" }
+androidx-credential-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "androidx-credential" }
+identity-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "identity-googleid" }
 
 [bundles]
 # jetpack compose로 생성했을 때 기본 제공되는 라이브러리들
@@ -73,6 +80,8 @@ androidx = ["androidx-ktx", "androidx-lifecycle", "androidx-activity-compose",
 api = ["retrofit2", "kotlin-serialization", "retrofit2-converter", "okhttp3"]
 # material3 최신 버전 적용을 위한 라이브러리
 material3 = ["material3", "material3-window", "material3-navigation"]
+# google login을 위한 credential manager jetpack
+credential = ["androidx-credential","androidx-credential-play-services-auth","identity-googleid"]
 
 
 [plugins]

--- a/Mobile/PomoroDo/gradle/libs.versions.toml
+++ b/Mobile/PomoroDo/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ okhttp3 = "4.11.0"
 # 종속성주입을 위한 라이브러리
 hilt = "2.44"
 # material3 최신 버전 적용을 위한 라이브러리
-material3 = "1.2.1"
+material3 = "1.3.0-beta04"
 material3-navigation = "1.3.0-beta02"
 # url 을 사용한 이미지 로딩을 위한 라이브러리
 glide-compose = "2.3.4"
@@ -28,8 +28,10 @@ compose-wheel-picker = "1.0.0-beta05"
 android-navigation = "2.8.0-beta02"
 hilt-navigation-compose = "1.2.0"
 # google login을 위한 credential manager jetpack
-androidx-credential = "1.2.2"
+androidx-credential = "1.3.0-beta02"
 identity-googleid = "1.1.1"
+# 암호화된 sharedpreference를 사용하기 위한 라이브러리
+androidx-security = "1.1.0-alpha06"
 
 
 [libraries]
@@ -52,6 +54,7 @@ retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref =
 kotlin-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlin-serialization-json" }
 retrofit2-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "kotlin-serealization-converter" }
 okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp3" }
+okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
 # 종속성주입을 위한 라이브러리
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
@@ -72,16 +75,19 @@ androidx-credential = { group = "androidx.credentials", name = "credentials", ve
 androidx-credential-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "androidx-credential" }
 identity-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "identity-googleid" }
 
+# 암호화된 sharedpreference를 사용하기 위한 라이브러리
+androidx-security = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "androidx-security" }
+
 [bundles]
 # jetpack compose로 생성했을 때 기본 제공되는 라이브러리들
 androidx = ["androidx-ktx", "androidx-lifecycle", "androidx-activity-compose",
     "compose-ui", "compose-graphic", "compose-preview", "androidx-navigation-compose"]
 # api 통신을 위한 라이브러리
-api = ["retrofit2", "kotlin-serialization", "retrofit2-converter", "okhttp3"]
+api = ["retrofit2", "kotlin-serialization", "retrofit2-converter", "okhttp3", "okhttp3-logging-interceptor"]
 # material3 최신 버전 적용을 위한 라이브러리
 material3 = ["material3", "material3-window", "material3-navigation"]
 # google login을 위한 credential manager jetpack
-credential = ["androidx-credential","androidx-credential-play-services-auth","identity-googleid"]
+credential = ["androidx-credential", "androidx-credential-play-services-auth", "identity-googleid"]
 
 
 [plugins]


### PR DESCRIPTION
**변경 사항**

- CustomTextButton에 border의 두께 변수 추가

- customTextField 다크모드 적용 안되는 문제 해결
  - 텍스트 컬러와 스타일, 커서 색상 적용

- 라이브러리 버전 변경
  - kotlin 버전에 맞는 hilt 버전으로 변경
    - 2.44 -> 2.46

- 불필요한 로그 제거 및 변경

---

**새로운 사항**

- 라이브러리 추가
  - google login을 위한 credential manager jetpack 라이브러리 추가
    - 1.3.0-beta04
  - 암호화된 sharedpreference를 사용하기 위한 라이브러리 추가
  - interceptor 추가를 위한 라이브러리 추가

- 리소스 추가
  - string
  - 다크모드 로그인을 위한 색상 추가

- 이미지 파일 생성하는 함수와 토스트 메시지를 띄우는 확장함수 추가

- 카메라 권한과 provider 설정

- 로그인 화면
  - 다크 모드와 오프라인 버튼 추가
  - 구글 로그인 기능 추가
  - 로그인과 회원가입에 필요한 authViewModel

- 사진 선택 Dialog 추가
  - 사진 촬영
  - 앨범에서 선택
  - 기존 이미지 적용(이미지가 있을때만 표시)

- 회원가입 화면
  - 카메라 권한 확인 코드 추가
  - dialog 추가로 컴포저블 분리
  - 사진 선택 도구 실행 기능 추가
  - camera 앱 활용 기능 추가

- sharedPreferences 추가
 
- google idToken을 viewmodel에 저장
- authToken을 sharedPreference에 저장


Fixes: TICO-133