### PR TITLE
[FIX] /api 경로에 X-Forwarded-Prefix 헤더 추가 (TICO-215)

### DIFF
--- a/nginx/conf/conf.d/default.conf
+++ b/nginx/conf/conf.d/default.conf
@@ -23,5 +23,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Prefix /api; # X-Forwarded-Prefix 헤더 설정 추가
     }
 }


### PR DESCRIPTION
/api/ 경로로 들어오는 요청이 프록시를 거쳐 백엔드 서버로 전달될 때, 요청 경로의 prefix를 명시적으로 전달

Related to: TICO-209