### PR TITLE
[FIX] "/api" 접두사를 사용한 REST API 엔드포인트 구현 (TICO-215)

### DIFF
--- a/backend/pomoro-do/build.gradle
+++ b/backend/pomoro-do/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 //	implementation 'com.google.api-client:google-api-client-jackson2:1.28.1'
 	implementation 'com.google.api-client:google-api-client-gson:2.6.0'
 
+	// 애플리케이션의 health check
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// JSON
 	implementation 'com.google.code.gson:gson'
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -27,7 +27,7 @@ import java.security.GeneralSecurityException;
 @Tag(name = "Auth: 인증", description = "인증 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("api/auth")
 public class AuthController {
     //사용자 로그인
     //사용자 로그아웃

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/base/AppInfoDTO.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/base/AppInfoDTO.java
@@ -1,0 +1,14 @@
+package com.tico.pomoro_do.global.base;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AppInfoDTO {
+    private String application;
+    private String version;
+    private String description;
+    private String message;
+    private String swaggerUrl;
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/config/SecurityConfig.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
 
     // 허용 주소
     private static final String[] WHITE_LIST = {
-            "auth/google/login", "auth/google/join", "/", "/token/reissue"
+            "/",
+            "/api/auth/google/**", "/api/auth/token/reissue"
     };
 
     private static final String[] swaggerURL = {
@@ -45,6 +46,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers("/error", "/favicon.ico")
+                .requestMatchers("/actuator/**")
                 .requestMatchers(swaggerURL);
     }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/controller/RootController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/controller/RootController.java
@@ -1,0 +1,32 @@
+package com.tico.pomoro_do.global.controller;
+
+import com.tico.pomoro_do.global.base.AppInfoDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "root", description = "애플리케이션 기본 정보 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/")
+public class RootController {
+
+    @Operation(summary = "애플리케이션 기본 정보", description = "애플리케이션의 기본 정보를 제공합니다.")
+    @GetMapping
+    public ResponseEntity<AppInfoDTO> getInfo() {
+        AppInfoDTO response = new AppInfoDTO(
+                "Pomoro-Do!",
+                "1.0.0",
+                "Pomoro-Do! 서비스에 오신 것을 환영합니다.",
+                "서비스가 정상적으로 실행 중입니다.",
+                "/swagger-ui.html"
+        );
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/backend/pomoro-do/src/main/resources/application.yml
+++ b/backend/pomoro-do/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 server:
   port: 8080 #애플리케이션 서버 포트번호 설정 (8080 포트에서 수신 대기하도록 설정)
-  forward-headers-strategy: FRAMEWORK # Spring-boot 서버에서 이용할 Forward-proxy와 관련된 설정
 
 spring:
   application:
@@ -37,6 +36,7 @@ jwt:
 # 구글 설정
 google:
   clientId: 271523854709-09eleiq014safhqqv0hasol452bqqqa8.apps.googleusercontent.com
+
 
 # Swagger
 springdoc:

--- a/nginx/conf/conf.d/default.conf
+++ b/nginx/conf/conf.d/default.conf
@@ -17,12 +17,11 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/pomorodo.shop/privkey.pem;
 
     # 원하는 서비스를 제공하는 2차 라우팅
-    location /api/ {
-        proxy_pass http://pomorodo.shop:8080/;
+    location /api {
+        proxy_pass http://pomorodo.shop:8080/api;
         proxy_redirect off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Prefix /api; # X-Forwarded-Prefix 헤더 설정 추가
     }
 }


### PR DESCRIPTION
- HTTPS와 HTTP 간의 프록시 설정 문제를 해결하기 위해 "/api" 접두사를 추가하여 REST API 엔드포인트 구현
- 기본 정보 API를 추가하여 애플리케이션 이름, 버전, 환영 메시지 등을 포함한 정보 반환
- Nginx의 프록시 설정을 수정하여 "/api" 접두사 추가

Related to: TICO-209, TICO-161, TICO-216