### PR TITLE
[FEAT] 팔로우 목록 UI 구현(TICO-68)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
@@ -7,6 +7,7 @@ import com.tico.pomorodo.data.model.TimeLineType
 import com.tico.pomorodo.data.model.TodoData
 import com.tico.pomorodo.data.model.TodoState
 import com.tico.pomorodo.data.model.User
+import com.tico.pomorodo.domain.model.Follow
 import java.time.LocalDateTime
 
 object DataSource {
@@ -268,5 +269,19 @@ object DataSource {
             completeGroupNumber = 0,
             likedNumber = 0
         )
+    )
+
+    val followList = listOf(
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
     )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/model/Follow.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/model/Follow.kt
@@ -1,0 +1,8 @@
+package com.tico.pomorodo.domain.model
+
+data class Follow(
+    val followId: Long,
+    val profileUrl: String? = null,
+    val name: String,
+    var isFollowing: Boolean
+)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -15,6 +15,7 @@ fun AppNavHost(
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     navigateToModifyProfile: () -> Unit,
+    navigateToFollowListScreen: () -> Unit,
     setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit,
 ) {
     val navController = appState.navController
@@ -29,6 +30,9 @@ fun AppNavHost(
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory
         )
-        myInfoScreen(navigateToModifyProfile = navigateToModifyProfile)
+        myInfoScreen(
+            navigateToModifyProfile = navigateToModifyProfile,
+            navigateToFollowListScreen = navigateToFollowListScreen
+        )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -14,6 +14,7 @@ import com.tico.pomorodo.ui.category.view.GroupMemberChooseScreenRoute
 import com.tico.pomorodo.ui.category.view.InfoCategoryScreenRoute
 import com.tico.pomorodo.ui.history.view.HistoryRoute
 import com.tico.pomorodo.ui.home.view.HomeScreen
+import com.tico.pomorodo.ui.member.view.FollowListScreen
 import com.tico.pomorodo.ui.member.view.ModifyProfileScreen
 import com.tico.pomorodo.ui.member.view.MyPageScreen
 import com.tico.pomorodo.ui.splash.view.SplashScreen
@@ -54,6 +55,9 @@ fun NavController.navigateToHistory() = navigate(MainNavigationDestination.Histo
 
 fun NavController.navigateToModifyProfile() = navigate(MainNavigationDestination.ModifyProfile.name)
 
+fun NavController.navigateToFollowListScreen() =
+    navigate(MainNavigationDestination.FollowListScreen.name)
+
 
 // home navigation - composable route
 fun NavGraphBuilder.timerScreen(
@@ -79,9 +83,15 @@ fun NavGraphBuilder.todoScreen(
     }
 }
 
-fun NavGraphBuilder.myInfoScreen(navigateToModifyProfile: () -> Unit) {
+fun NavGraphBuilder.myInfoScreen(
+    navigateToModifyProfile: () -> Unit,
+    navigateToFollowListScreen: () -> Unit
+) {
     composable(route = BottomNavigationDestination.MyInfo.name) {
-        MyPageScreen(navigateToModifyProfile = navigateToModifyProfile)
+        MyPageScreen(
+            navigateToModifyProfile = navigateToModifyProfile,
+            navigateToFollowListScreen = navigateToFollowListScreen
+        )
     }
 }
 
@@ -116,7 +126,8 @@ fun NavGraphBuilder.homeScreen(
     navigateToCategory: () -> Unit,
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
-    navigateToModifyProfile: () -> Unit
+    navigateToModifyProfile: () -> Unit,
+    navigateToFollowListScreen: () -> Unit
 ) {
     composable(route = MainNavigationDestination.Home.name) {
         HomeScreen(
@@ -125,7 +136,8 @@ fun NavGraphBuilder.homeScreen(
             navigateToCategory = navigateToCategory,
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory,
-            navigateToModifyProfile = navigateToModifyProfile
+            navigateToModifyProfile = navigateToModifyProfile,
+            navigateToFollowListScreen = navigateToFollowListScreen
         )
     }
 }
@@ -237,5 +249,11 @@ fun NavGraphBuilder.groupMemberChooseScreen(
 fun NavGraphBuilder.modifyProfileScreen(navController: NavController) {
     composable(route = MainNavigationDestination.ModifyProfile.name) { navBackStackEntry ->
         ModifyProfileScreen(navController = navController, navBackStackEntry = navBackStackEntry)
+    }
+}
+
+fun NavGraphBuilder.followListScreen() {
+    composable(route = MainNavigationDestination.FollowListScreen.name) {
+        FollowListScreen()
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
@@ -44,4 +44,5 @@ enum class MainNavigationDestination {
     History,
 
     ModifyProfile,
+    FollowListScreen,
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -19,6 +19,7 @@ import com.tico.pomorodo.navigation.addCategoryScreen
 import com.tico.pomorodo.navigation.breakModeScreen
 import com.tico.pomorodo.navigation.categoryScreen
 import com.tico.pomorodo.navigation.concentrationModeScreen
+import com.tico.pomorodo.navigation.followListScreen
 import com.tico.pomorodo.navigation.getState
 import com.tico.pomorodo.navigation.groupMemberChooseScreen
 import com.tico.pomorodo.navigation.historyScreen
@@ -30,6 +31,7 @@ import com.tico.pomorodo.navigation.navigateToAddCategory
 import com.tico.pomorodo.navigation.navigateToBreakMode
 import com.tico.pomorodo.navigation.navigateToCategory
 import com.tico.pomorodo.navigation.navigateToConcentrationMode
+import com.tico.pomorodo.navigation.navigateToFollowListScreen
 import com.tico.pomorodo.navigation.navigateToGroupMemberChoose
 import com.tico.pomorodo.navigation.navigateToHistory
 import com.tico.pomorodo.navigation.navigateToHome
@@ -86,7 +88,8 @@ fun MainScreen() {
                     navigateToCategory = mainNavController::navigateToCategory,
                     navigateToAddCategory = mainNavController::navigateToAddCategory,
                     navigateToHistory = mainNavController::navigateToHistory,
-                    navigateToModifyProfile = mainNavController::navigateToModifyProfile
+                    navigateToModifyProfile = mainNavController::navigateToModifyProfile,
+                    navigateToFollowListScreen = mainNavController::navigateToFollowListScreen
                 )
 
                 concentrationModeScreen(
@@ -119,6 +122,7 @@ fun MainScreen() {
                 historyScreen(navigateToBack = mainNavController::popBackStack)
 
                 modifyProfileScreen(navController = mainNavController)
+                followListScreen()
             }
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
@@ -16,6 +16,7 @@ fun HomeScreen(
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     navigateToModifyProfile: () -> Unit,
+    navigateToFollowListScreen: () -> Unit,
     setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit
 ) {
     val homeNavController = rememberNavController()
@@ -34,6 +35,7 @@ fun HomeScreen(
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory,
             navigateToModifyProfile = navigateToModifyProfile,
+            navigateToFollowListScreen = navigateToFollowListScreen,
             setTimerState = setTimerState,
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
@@ -1,43 +1,73 @@
 package com.tico.pomorodo.ui.member.view
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.request.RequestOptions
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.glide.GlideImage
 import com.tico.pomorodo.R
+import com.tico.pomorodo.domain.model.Follow
+import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.SimpleIconButton
+import com.tico.pomorodo.ui.member.viewmodel.FollowViewModel
 import com.tico.pomorodo.ui.theme.IC_ARROW_BACK
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
+import kotlinx.coroutines.launch
 
-@Preview
 @Composable
 fun FollowListScreen() {
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val followViewModel: FollowViewModel = hiltViewModel()
+    val followerList by followViewModel.followerList.collectAsState()
+    val followingList by followViewModel.followingList.collectAsState()
+    val pagerState = rememberPagerState(pageCount = { 2 })
+    val coroutineScope = rememberCoroutineScope()
 
-    PomoroDoTheme {
-        Column {
-            TopAppBarWithSingleButton()
+    Column(modifier = Modifier.background(color = PomoroDoTheme.colorScheme.background)) {
+        TopAppBarWithSingleButton()
 
-            FollowTabRow(selectedTabIndex = selectedTabIndex) { index ->
-                selectedTabIndex = index
-            }
+        FollowTabRow(selectedTabIndex = pagerState.currentPage) { index ->
+            coroutineScope.launch { pagerState.animateScrollToPage(index) }
+        }
+
+        HorizontalPager(state = pagerState) { page ->
+            if (page == 0) FollowingList(followList = followerList.toMutableStateList())
+            else FollowerList(followList = followingList.toMutableStateList())
         }
     }
 }
@@ -47,7 +77,6 @@ fun TopAppBarWithSingleButton() {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(color = PomoroDoTheme.colorScheme.background)
             .padding(start = 18.dp, end = 18.dp, top = 24.dp, bottom = 14.dp),
         contentAlignment = Alignment.CenterStart
     ) {
@@ -60,7 +89,7 @@ fun TopAppBarWithSingleButton() {
         )
 
         Text(
-            text = stringResource(R.string.title_follow_list),
+            text = stringResource(R.string.title_follow),
             modifier = Modifier.fillMaxWidth(),
             color = PomoroDoTheme.colorScheme.onBackground,
             textAlign = TextAlign.Center,
@@ -109,6 +138,111 @@ fun FollowTabRow(selectedTabIndex: Int, onSelectedTabIndexChange: (Int) -> Unit)
                     style = PomoroDoTheme.typography.laundryGothicRegular16
                 )
             }
+        )
+    }
+}
+
+@Composable
+fun FollowingList(followList: SnapshotStateList<Follow>) {
+    LazyColumn(
+        modifier = Modifier
+            .padding(horizontal = 18.dp)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(18.dp)
+    ) {
+        itemsIndexed(items = followList) { index, user ->
+            if (index == 0)
+                Spacer(modifier = Modifier.height(18.dp))
+
+            FollowItem(
+                user = user,
+                followButtonText = stringResource(id = R.string.title_following),
+                unFollowButtonText = stringResource(id = R.string.title_follow),
+                followButtonContainerColor = PomoroDoTheme.colorScheme.gray90,
+                followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
+                unFollowButtonContainerColor = PomoroDoTheme.colorScheme.primaryContainer,
+                unFollowButtonContentColor = Color.White,
+                onClick = { followList[index] = user.copy(isFollowing = !user.isFollowing) }
+            )
+        }
+    }
+}
+
+@Composable
+fun FollowerList(followList: SnapshotStateList<Follow>) {
+    LazyColumn(
+        modifier = Modifier
+            .padding(top = 18.dp, start = 18.dp, end = 18.dp)
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(18.dp)
+    ) {
+        items(items = followList) { user ->
+            FollowItem(
+                user = user,
+                followButtonText = stringResource(id = R.string.content_delete),
+                followButtonContainerColor = PomoroDoTheme.colorScheme.gray90,
+                followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
+                onClick = { followList.remove(user) }
+            )
+        }
+    }
+}
+
+@Composable
+fun FollowItem(
+    user: Follow,
+    followButtonText: String,
+    unFollowButtonText: String? = null,
+    followButtonContainerColor: Color,
+    followButtonContentColor: Color,
+    unFollowButtonContainerColor: Color? = null,
+    unFollowButtonContentColor: Color? = null,
+    onClick: () -> Unit
+) {
+    val buttonText =
+        if (user.isFollowing) followButtonText
+        else unFollowButtonText ?: followButtonText
+    val buttonContainerColor =
+        if (user.isFollowing) followButtonContainerColor
+        else unFollowButtonContainerColor ?: followButtonContainerColor
+    val buttonContentColor =
+        if (user.isFollowing) followButtonContentColor
+        else unFollowButtonContentColor ?: followButtonContentColor
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        GlideImage(
+            imageModel = { user.profileUrl },
+            modifier = Modifier
+                .size(48.dp)
+                .clip(shape = CircleShape),
+            requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.AUTOMATIC) },
+            imageOptions = ImageOptions(
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.Center
+            )
+        )
+
+        Text(
+            text = user.name,
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Start,
+            style = PomoroDoTheme.typography.laundryGothicRegular18
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        CustomTextButton(
+            text = buttonText,
+            containerColor = buttonContainerColor,
+            contentColor = buttonContentColor,
+            textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
+            verticalPadding = 8.dp,
+            horizontalPadding = 15.dp,
+            onClick = onClick
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
@@ -1,0 +1,57 @@
+package com.tico.pomorodo.ui.member.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.common.view.SimpleIconButton
+import com.tico.pomorodo.ui.theme.IC_ARROW_BACK
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Preview
+@Composable
+fun FollowListScreen() {
+    PomoroDoTheme {
+        Column {
+            TopAppBarWithSingleButton()
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TopAppBarWithSingleButton() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = PomoroDoTheme.colorScheme.background)
+            .padding(start = 18.dp, end = 18.dp, top = 24.dp, bottom = 14.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        SimpleIconButton(
+            size = 28,
+            imageVector = PomoroDoTheme.iconPack[IC_ARROW_BACK]!!,
+            contentDescriptionId = R.string.content_ic_arrow_back,
+            enabled = true,
+            onClickedListener = { /*TODO: top app bar - pop back stack*/ }
+        )
+
+        Text(
+            text = stringResource(R.string.title_follow_list),
+            modifier = Modifier.fillMaxWidth(),
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            style = PomoroDoTheme.typography.laundryGothicBold20
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
@@ -5,8 +5,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,14 +29,19 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Preview
 @Composable
 fun FollowListScreen() {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+
     PomoroDoTheme {
         Column {
             TopAppBarWithSingleButton()
+
+            FollowTabRow(selectedTabIndex = selectedTabIndex) { index ->
+                selectedTabIndex = index
+            }
         }
     }
 }
 
-@Preview
 @Composable
 fun TopAppBarWithSingleButton() {
     Box(
@@ -52,6 +65,50 @@ fun TopAppBarWithSingleButton() {
             color = PomoroDoTheme.colorScheme.onBackground,
             textAlign = TextAlign.Center,
             style = PomoroDoTheme.typography.laundryGothicBold20
+        )
+    }
+}
+
+@Composable
+fun FollowTabRow(selectedTabIndex: Int, onSelectedTabIndexChange: (Int) -> Unit) {
+    val textColor = PomoroDoTheme.colorScheme.onBackground
+
+    TabRow(
+        selectedTabIndex = selectedTabIndex,
+        containerColor = PomoroDoTheme.colorScheme.background,
+        contentColor = textColor,
+        indicator = { tabPositions ->
+            TabRowDefaults.SecondaryIndicator(
+                modifier = Modifier.tabIndicatorOffset(
+                    tabPositions[selectedTabIndex]
+                ), color = PomoroDoTheme.colorScheme.primaryContainer
+            )
+        }
+    ) {
+        Tab(
+            selected = selectedTabIndex == 0,
+            onClick = { onSelectedTabIndexChange(0) },
+            text = {
+                Text(
+                    text = stringResource(R.string.title_following),
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    style = PomoroDoTheme.typography.laundryGothicRegular16
+                )
+            }
+        )
+
+        Tab(
+            selected = selectedTabIndex == 1,
+            onClick = { onSelectedTabIndexChange(1) },
+            text = {
+                Text(
+                    text = stringResource(id = R.string.title_follower),
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    style = PomoroDoTheme.typography.laundryGothicRegular16
+                )
+            }
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/FollowListScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -26,8 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,8 +63,14 @@ fun FollowListScreen() {
         }
 
         HorizontalPager(state = pagerState) { page ->
-            if (page == 0) FollowingList(followList = followerList.toMutableStateList())
-            else FollowerList(followList = followingList.toMutableStateList())
+            if (page == 0) FollowingList(
+                followList = followingList,
+                toggleFollowState = followViewModel::toggleFollowState
+            )
+            else FollowerList(
+                followList = followerList,
+                removeFollower = followViewModel::removeFollower
+            )
         }
     }
 }
@@ -143,7 +146,7 @@ fun FollowTabRow(selectedTabIndex: Int, onSelectedTabIndexChange: (Int) -> Unit)
 }
 
 @Composable
-fun FollowingList(followList: SnapshotStateList<Follow>) {
+fun FollowingList(followList: List<Follow>, toggleFollowState: (Int) -> Unit) {
     LazyColumn(
         modifier = Modifier
             .padding(horizontal = 18.dp)
@@ -162,27 +165,27 @@ fun FollowingList(followList: SnapshotStateList<Follow>) {
                 followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
                 unFollowButtonContainerColor = PomoroDoTheme.colorScheme.primaryContainer,
                 unFollowButtonContentColor = Color.White,
-                onClick = { followList[index] = user.copy(isFollowing = !user.isFollowing) }
+                onClick = { toggleFollowState(index) }
             )
         }
     }
 }
 
 @Composable
-fun FollowerList(followList: SnapshotStateList<Follow>) {
+fun FollowerList(followList: List<Follow>, removeFollower: (Int) -> Unit) {
     LazyColumn(
         modifier = Modifier
             .padding(top = 18.dp, start = 18.dp, end = 18.dp)
             .fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(18.dp)
     ) {
-        items(items = followList) { user ->
+        itemsIndexed(items = followList) { index, user ->
             FollowItem(
                 user = user,
                 followButtonText = stringResource(id = R.string.content_delete),
                 followButtonContainerColor = PomoroDoTheme.colorScheme.gray90,
                 followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
-                onClick = { followList.remove(user) }
+                onClick = { removeFollower(index) }
             )
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/MyPageScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/MyPageScreen.kt
@@ -41,7 +41,7 @@ import com.tico.pomorodo.ui.theme.IconPack
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
-fun MyPageScreen(navigateToModifyProfile: () -> Unit) {
+fun MyPageScreen(navigateToModifyProfile: () -> Unit, navigateToFollowListScreen: () -> Unit) {
     val authViewModel: AuthViewModel = hiltViewModel()
     val name by authViewModel.name.collectAsState()
     val profileUri by authViewModel.profile.collectAsState()
@@ -81,7 +81,8 @@ fun MyPageScreen(navigateToModifyProfile: () -> Unit) {
             userName = name,
             followingCount = 4,
             followerCount = 2,
-            onProfileClick = navigateToModifyProfile
+            onProfileClick = navigateToModifyProfile,
+            onFollowListClick = navigateToFollowListScreen
         )
 
         Spacer(modifier = Modifier.height(28.dp))
@@ -125,7 +126,8 @@ fun MyProfile(
     userName: String,
     followingCount: Int,
     followerCount: Int,
-    onProfileClick: () -> Unit
+    onProfileClick: () -> Unit,
+    onFollowListClick: () -> Unit
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -148,7 +150,7 @@ fun MyProfile(
             )
 
             Row(
-                modifier = Modifier.clickableWithoutRipple { /*TODO: 팔로우 화면이 나타남.*/ },
+                modifier = Modifier.clickableWithoutRipple { onFollowListClick() },
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 FollowText(title = stringResource(R.string.title_following), count = followingCount)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/FollowViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/FollowViewModel.kt
@@ -10,9 +10,23 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FollowViewModel @Inject constructor() : ViewModel() {
+    private val _followingList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
+    val followingList: StateFlow<List<Follow>> = _followingList
+
     private val _followerList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
     val followerList: StateFlow<List<Follow>> = _followerList
 
-    private val _followingList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
-    val followingList: StateFlow<List<Follow>> = _followingList
+    fun toggleFollowState(index: Int) {
+        val list = _followingList.value.toMutableList()
+        list[index] = list[index].copy(isFollowing = !list[index].isFollowing)
+
+        _followingList.value = list.toList()
+    }
+
+    fun removeFollower(index: Int) {
+        val list = _followerList.value.toMutableList()
+        list.removeAt(index)
+
+        _followerList.value = list.toList()
+    }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/FollowViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/FollowViewModel.kt
@@ -1,0 +1,18 @@
+package com.tico.pomorodo.ui.member.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.tico.pomorodo.data.local.datasource.DataSource.followList
+import com.tico.pomorodo.domain.model.Follow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class FollowViewModel @Inject constructor() : ViewModel() {
+    private val _followerList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
+    val followerList: StateFlow<List<Follow>> = _followerList
+
+    private val _followingList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
+    val followingList: StateFlow<List<Follow>> = _followingList
+}

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">PomoroDo</string>
+
     // splash
     <string name="content_ic_title">뽀모로 Do! 타이틀 로고</string>
 
@@ -148,18 +149,6 @@
     <string name="title_finish_break">휴식 모드 종료</string>
     <string name="content_finish_break">휴식 모드를 종료하시겠습니까?</string>
 
-    // common
-    <string name="content_next">다음</string>
-    <string name="content_cancel">취소</string>
-    <string name="content_ok">확인</string>
-    <string name="content_delete">삭제</string>
-    <string name="content_finish">종료</string>
-    <string name="content_reset">초기화</string>
-
-    // time format
-    <string name="format_hour_minute">%02d:%02d</string>
-    <string name="format_hour_minute_second">%02d:%02d:%02d</string>
-
     // bottom navigation bar
     <string name="title_timer">타이머</string>
     <string name="title_todo">할 일 목록</string>
@@ -170,8 +159,6 @@
 
     // my page
     <string name="content_ic_setting">환경설정 아이콘</string>
-    <string name="title_following">팔로잉</string>
-    <string name="title_follower">팔로워</string>
     <string name="title_invite">친구 초대</string>
     <string name="title_alarm_concentration">집중 종료 알림</string>
     <string name="title_alarm_break">휴식 종료 알림</string>
@@ -188,6 +175,20 @@
     // my page - modify profile
     <string name="title_modify_profile">프로필 수정</string>
 
-    // my page - follow list
-    <string name="title_follow_list">팔로우</string>
+    // common
+    <string name="content_next">다음</string>
+    <string name="content_cancel">취소</string>
+    <string name="content_ok">확인</string>
+    <string name="content_delete">삭제</string>
+    <string name="content_finish">종료</string>
+    <string name="content_reset">초기화</string>
+
+    // common - time format
+    <string name="format_hour_minute">%02d:%02d</string>
+    <string name="format_hour_minute_second">%02d:%02d:%02d</string>
+
+    // common - follow
+    <string name="title_follow">팔로우</string>
+    <string name="title_following">팔로잉</string>
+    <string name="title_follower">팔로워</string>
 </resources>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -185,6 +185,9 @@
     <string name="content_alarm_option_vibrate">진동</string>
     <string name="content_alarm_option_mute">무음</string>
 
-    // modify profile
+    // my page - modify profile
     <string name="title_modify_profile">프로필 수정</string>
+
+    // my page - follow list
+    <string name="title_follow_list">팔로우</string>
 </resources>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -175,6 +175,12 @@
     // my page - modify profile
     <string name="title_modify_profile">프로필 수정</string>
 
+    // my page - follow list
+    <string name="title_unfollow_dialog">팔로우 해제</string>
+    <string name="content_unfollow_dialog">팔로우를 해제 하시겠습니까?\n해제 후 목록에서 다시 팔로우 할 수 있습니다.</string>
+    <string name="title_remove_follower_dialog">팔로워 삭제</string>
+    <string name="content_remove_follower_dialog">팔로워를 삭제하시겠습니까?\n팔로워를 삭제하면 목록에서 사라집니다.</string>
+
     // common
     <string name="content_next">다음</string>
     <string name="content_cancel">취소</string>
@@ -189,6 +195,7 @@
 
     // common - follow
     <string name="title_follow">팔로우</string>
+    <string name="content_unfollow">언팔로우</string>
     <string name="title_following">팔로잉</string>
     <string name="title_follower">팔로워</string>
 </resources>


### PR DESCRIPTION
- 뒤로가기 버튼과 제목만 있는 상단바 구현
- 팔로우 메뉴 탭 구현
- 팔로우 목록을 좌우로 드래그하여 각 메뉴끼리 화면을 전환할 수 있도록 구현
- 팔로우 데이터 모델 생성
  - followId: 팔로우 id
  - profileUrl: 프로필 url
  - name: 사용자 이름
  - isFollowing: 팔로우 여부(변경 가능 변수)
- 임시 데이터 생성(followList)

Resolves: TICO-68
Related to: TICO-61