### PR TITLE
[FEAT] UI 보충 (TICO-204)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
@@ -1,7 +1,9 @@
 package com.tico.pomorodo.data.local.datasource
 
 import com.tico.pomorodo.data.model.Category
+import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.InviteCategory
+import com.tico.pomorodo.data.model.OpenSettings
 import com.tico.pomorodo.data.model.TimeLineData
 import com.tico.pomorodo.data.model.TimeLineType
 import com.tico.pomorodo.data.model.TodoData
@@ -31,7 +33,17 @@ object DataSource {
         Category(
             id = "1",
             title = "카테고리 1",
-            groupNumber = 5,
+            groupNumber = 4,
+            type = CategoryType.GROUP,
+            openSettings = OpenSettings.GROUP,
+            isGroupReader = true,
+            groupReader = "모카커피짱귀엽",
+            groupMember = listOf(
+                User(id = "3", name = "구름이1"),
+                User(id = "4", name = "구름이2"),
+                User(id = "5", name = "구름이3"),
+                User(id = "6", name = "구름이4")
+            ),
             todoList = listOf(
                 TodoData(
                     id = "1",
@@ -70,6 +82,8 @@ object DataSource {
         Category(
             id = "2",
             title = "카테고리 2",
+            type = CategoryType.NORMAL,
+            openSettings = OpenSettings.FULL,
             todoList = listOf(
                 TodoData(
                     id = "1",
@@ -84,6 +98,8 @@ object DataSource {
         Category(
             id = "3",
             title = "카테고리 3",
+            type = CategoryType.NORMAL,
+            openSettings = OpenSettings.ME,
             todoList = listOf(
                 TodoData(
                     id = "1",
@@ -102,7 +118,56 @@ object DataSource {
                     likedNumber = 22
                 ),
             )
-        )
+        ),
+        Category(
+            id = "4",
+            title = "카테고리 4",
+            groupNumber = 4,
+            type = CategoryType.GROUP,
+            openSettings = OpenSettings.GROUP,
+            isGroupReader = false,
+            groupReader = "구름이짠나",
+            groupMember = listOf(
+                User(id = "3", name = "구름이1"),
+                User(id = "4", name = "구름이2"),
+                User(id = "5", name = "구름이3"),
+                User(id = "6", name = "구름이4")
+            ),
+            todoList = listOf(
+                TodoData(
+                    id = "1",
+                    name = "Todo 1",
+                    state = TodoState.UNCHECKED,
+                    categoryId = "1",
+                    completeGroupNumber = 4,
+                    likedNumber = 22
+                ),
+                TodoData(
+                    id = "2",
+                    name = "Todo 1",
+                    state = TodoState.CHECKED,
+                    categoryId = "1",
+                    completeGroupNumber = 1,
+                    likedNumber = 22
+                ),
+                TodoData(
+                    id = "3",
+                    name = "Todo 1",
+                    state = TodoState.GOING,
+                    categoryId = "1",
+                    completeGroupNumber = 3,
+                    likedNumber = 22
+                ),
+                TodoData(
+                    id = "4",
+                    name = "Todo 1",
+                    state = TodoState.UNCHECKED,
+                    categoryId = "1",
+                    completeGroupNumber = 0,
+                    likedNumber = 0
+                )
+            )
+        ),
     )
 
     val inviteList = listOf<InviteCategory>(

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/Category.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/Category.kt
@@ -3,6 +3,15 @@ package com.tico.pomorodo.data.model
 data class Category(
     val id: String,
     val title: String,
-    val todoList: List<TodoData>,
-    val groupNumber: Int = 0
+    val type: CategoryType,
+    val todoList: List<TodoData>? = null,
+    val openSettings: OpenSettings = OpenSettings.FULL,
+    val groupNumber: Int = 0,
+    val groupReader: String? = null,
+    val isGroupReader: Boolean? = null,
+    val groupMember: List<User>? = null
 )
+
+enum class CategoryType {
+    NORMAL, GROUP
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -101,10 +101,13 @@ fun MainScreen() {
                 categoryScreen(
                     navigateToAddCategory = mainNavController::navigateToAddCategory,
                     navigateToBack = mainNavController::popBackStack,
-                    navigateToInfoCategory = mainNavController::navigateToInfoCategory
+                    navigateToInfoCategory = { categoryId ->
+                        mainNavController.navigateToInfoCategory(
+                            categoryId = categoryId
+                        )
+                    }
                 )
                 addCategoryScreen(
-                    navController = mainNavController,
                     navigateToCategory = mainNavController::navigateToCategory,
                     navigateToGroupMemberChoose = mainNavController::navigateToGroupMemberChoose,
                     navigateToBack = mainNavController::popBackStack

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/AddCategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/AddCategoryScreen.kt
@@ -208,11 +208,13 @@ fun CategoryOpenSettings(
                     )
                 }
             }
-            SimpleText(
-                textId = R.string.content_only_group_message,
-                style = PomoroDoTheme.typography.laundryGothicRegular10,
-                color = PomoroDoTheme.colorScheme.gray50
-            )
+            if(!enabled){
+                SimpleText(
+                    textId = R.string.content_only_group_message,
+                    style = PomoroDoTheme.typography.laundryGothicRegular10,
+                    color = PomoroDoTheme.colorScheme.gray50
+                )
+            }
         }
     }
 }
@@ -244,6 +246,7 @@ private fun CategoryType(
                 padding = PaddingValues(horizontal = 5.dp)
             )
             SimpleText(
+                modifier = Modifier.clickableWithoutRipple { onTypeChanged(true) },
                 textId = R.string.content_category_normal,
                 style = PomoroDoTheme.typography.laundryGothicRegular14,
                 color = PomoroDoTheme.colorScheme.onBackground
@@ -255,6 +258,7 @@ private fun CategoryType(
                 padding = PaddingValues(horizontal = 5.dp)
             )
             SimpleText(
+                modifier = Modifier.clickableWithoutRipple { onTypeChanged(false) },
                 textId = R.string.content_category_group,
                 style = PomoroDoTheme.typography.laundryGothicRegular14,
                 color = PomoroDoTheme.colorScheme.onBackground

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryOutDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryOutDialog.kt
@@ -23,16 +23,17 @@ import com.tico.pomorodo.ui.common.view.SimpleText
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
-fun GroupOutDialog(
-    groupName: String,
+fun CategoryOutDialog(
+    title: String,
+    content: String,
     onAllDeleteClicked: () -> Unit,
     onIncompletedTodoDeleteClicked: () -> Unit,
     onNoDeleteClicked: () -> Unit,
-    onDismissRequest: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
 ) {
     val colors = CardDefaults.cardColors(containerColor = PomoroDoTheme.colorScheme.dialogSurface)
     Dialog(
-        onDismissRequest = { onDismissRequest(false) },
+        onDismissRequest = onDismissRequest,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         Card(
@@ -47,14 +48,14 @@ fun GroupOutDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 SimpleText(
-                    textId = R.string.title_group_out,
+                    text = title,
                     style = PomoroDoTheme.typography.laundryGothicBold20,
                     color = PomoroDoTheme.colorScheme.onBackground,
                 )
                 Spacer(modifier = Modifier.height(14.dp))
                 SimpleText(
                     modifier = Modifier,
-                    text = stringResource(id = R.string.content_group_out_message, groupName),
+                    text = content,
                     style = PomoroDoTheme.typography.laundryGothicRegular14,
                     color = PomoroDoTheme.colorScheme.onBackground,
                     textAlign = TextAlign.Center
@@ -91,7 +92,7 @@ fun GroupOutDialog(
                         contentColor = Color.White,
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
                         verticalPadding = 8.dp,
-                        onClick = { onDismissRequest(false) }
+                        onClick = onDismissRequest
                     )
                 }
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
@@ -25,8 +25,8 @@ import com.tico.pomorodo.R
 import com.tico.pomorodo.data.model.Category
 import com.tico.pomorodo.data.model.InviteCategory
 import com.tico.pomorodo.ui.category.viewModel.CategoryViewModel
-import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.CustomTextButton
+import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.SimpleText
 import com.tico.pomorodo.ui.common.view.clickableWithoutRipple
 import com.tico.pomorodo.ui.theme.IC_ADD_CATEGORY
@@ -38,7 +38,7 @@ fun CategoryScreen(
     normalCategoryList: List<Category>,
     groupCategoryList: List<Category>,
     inviteGroupCategoryList: List<InviteCategory>,
-    onCategoryClicked: () -> Unit
+    onCategoryClicked: (String) -> Unit
 ) {
     Surface(
         modifier = Modifier
@@ -64,7 +64,7 @@ fun CategoryScreen(
                             modifier = Modifier
                                 .clickableWithoutRipple(
                                     enabled = true,
-                                    onClick = onCategoryClicked
+                                    onClick = { onCategoryClicked(category.id) }
                                 )
                                 .fillMaxWidth()
                         ) {
@@ -85,7 +85,7 @@ fun CategoryScreen(
                             modifier = Modifier
                                 .clickableWithoutRipple(
                                     enabled = true,
-                                    onClick = onCategoryClicked
+                                    onClick = { onCategoryClicked(category.id) }
                                 )
                                 .fillMaxWidth()
                         ) {
@@ -187,7 +187,7 @@ fun CategoryScreenRoute(
     categoryViewModel: CategoryViewModel = hiltViewModel(),
     navigateToAddCategory: () -> Unit,
     navigateToBack: () -> Unit,
-    navigateToInfoCategory: () -> Unit
+    navigateToInfoCategory: (String) -> Unit
 ) {
     val categoryList by categoryViewModel.categoryList.collectAsState()
     val inviteGroupCategoryList by categoryViewModel.inviteGroupCategoryList.collectAsState()

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
@@ -68,11 +68,7 @@ fun CategoryScreen(
                                 )
                                 .fillMaxWidth()
                         ) {
-                            CategoryTag(
-                                title = category.title,
-                                groupNumber = 0,
-                                isAddButton = false,
-                            )
+                            CategoryTag(title = category.title, groupNumber = 0)
                         }
                     }
                 }
@@ -93,11 +89,7 @@ fun CategoryScreen(
                                 )
                                 .fillMaxWidth()
                         ) {
-                            CategoryTag(
-                                title = category.title,
-                                groupNumber = 6,
-                                isAddButton = false,
-                            )
+                            CategoryTag(title = category.title, groupNumber = 6)
                         }
                     }
                 }
@@ -111,8 +103,8 @@ fun CategoryScreen(
                 Column(modifier = Modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     inviteGroupCategoryList.forEach { category ->
                         InvitedCategoryItem(
-                            category.title,
-                            category.groupReader,
+                            title = category.title,
+                            groupReader = category.groupReader,
                             onAcceptButtonClicked = {},
                             onRejectButtonClicked = {}
                         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/InfoCategoryScreen.kt
@@ -30,13 +30,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tico.pomorodo.R
+import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.OpenSettings
-import com.tico.pomorodo.ui.category.viewModel.CategoryViewModel
-import com.tico.pomorodo.ui.common.view.CustomTopAppBar
+import com.tico.pomorodo.navigation.MainNavigationDestination
+import com.tico.pomorodo.ui.category.viewModel.InfoCategoryViewModel
 import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTextField
+import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.SimpleText
 import com.tico.pomorodo.ui.common.view.addFocusCleaner
+import com.tico.pomorodo.ui.common.view.getNoSpace
 import com.tico.pomorodo.ui.theme.IC_OK
 import com.tico.pomorodo.ui.theme.IC_UNOK
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
@@ -45,10 +48,10 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InfoCategoryScreenRoute(
-    viewModel: CategoryViewModel = hiltViewModel(),
+    viewModel: InfoCategoryViewModel = hiltViewModel(),
     navigateToBack: () -> Unit,
     navigateToCategory: () -> Unit,
-    navigateToGroupMemberChoose: () -> Unit,
+    navigateToGroupMemberChoose: (String) -> Unit,
 ) {
     val openSettingsOptionSheetState = rememberModalBottomSheetState()
     val checkGroupMemberSheetState = rememberModalBottomSheetState()
@@ -56,99 +59,137 @@ fun InfoCategoryScreenRoute(
 
     var showOpenSettingsBottomSheet by rememberSaveable { mutableStateOf(false) }
     var showCheckGroupMemberBottomSheet by rememberSaveable { mutableStateOf(false) }
-    val isGroupReader by rememberSaveable { mutableStateOf(false) }
-    var groupDeleteDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var groupDeleteFirstDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var groupDeleteSecondDialogVisible by rememberSaveable { mutableStateOf(false) }
     var groupOutDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var normalOutDialogVisible by rememberSaveable { mutableStateOf(false) }
 
-    val title by viewModel.title.collectAsState()
-    val type by viewModel.type.collectAsState()
-    val openSettingOption by viewModel.openSettingOption.collectAsState()
-    val groupMembers by viewModel.groupMembers.collectAsState()
+    val category by viewModel.category.collectAsState()
     val selectedGroupMembers by viewModel.selectedGroupMembers.collectAsState()
+
+    var deleteDialogInputText by rememberSaveable {
+        mutableStateOf("")
+    }
 
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    Surface(
-        modifier = Modifier
-            .fillMaxSize()
-            .addFocusCleaner(focusManager) {
-                keyboardController?.hide()
-            },
-        color = PomoroDoTheme.colorScheme.background,
-    ) {
-        Column(
-            Modifier
-                .verticalScroll(rememberScrollState())
-                .fillMaxSize(),
+    if (category == null) {
+        // TODO: 데이터 로딩 화면
+    } else {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .addFocusCleaner(focusManager) {
+                    keyboardController?.hide()
+                },
+            color = PomoroDoTheme.colorScheme.background,
         ) {
-            CustomTopAppBar(
-                modifier = Modifier,
-                titleTextId = R.string.title_info_category,
-                iconString = IC_OK,
-                disableIconString = IC_UNOK,
-                enabled = selectedGroupMembers.any { it.selected } && viewModel.validateInput(),
-                descriptionId = R.string.content_ic_ok,
-                onClickedListener = {
-                    navigateToCategory()
-                },
-                onBackClickedListener = navigateToBack
-            )
-            if (showCheckGroupMemberBottomSheet) {
-                CheckGroupMemberBottomSheet(
-                    sheetState = checkGroupMemberSheetState,
-                    onShowBottomSheetChange = { showCheckGroupMemberBottomSheet = it },
-                    memberList = groupMembers
+            Column(
+                Modifier
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxSize(),
+            ) {
+                CustomTopAppBar(
+                    modifier = Modifier,
+                    titleTextId = R.string.title_info_category,
+                    iconString = IC_OK,
+                    disableIconString = IC_UNOK,
+                    enabled = selectedGroupMembers.any { it.selected } && viewModel.validateInput(),
+                    descriptionId = R.string.content_ic_ok,
+                    onClickedListener = {
+                        navigateToCategory()
+                    },
+                    onBackClickedListener = navigateToBack
                 )
-            }
-            if (showOpenSettingsBottomSheet) {
-                OpenSettingsBottomSheet(
-                    title = stringResource(id = R.string.title_open_settings),
-                    sheetState = openSettingsOptionSheetState,
-                    openSettingOption = openSettingOption,
-                    onShowBottomSheetChange = { showOpenSettingsBottomSheet = it },
-                    onOkButtonClicked = {
-                        viewModel.setOpenSettingOption(it)
-                        scope.launch { openSettingsOptionSheetState.hide() }
-                            .invokeOnCompletion {
-                                if (!openSettingsOptionSheetState.isVisible) {
-                                    showOpenSettingsBottomSheet = false
-                                }
-                            }
+                if (showCheckGroupMemberBottomSheet) {
+                    category!!.groupMember?.let {
+                        CheckGroupMemberBottomSheet(
+                            sheetState = checkGroupMemberSheetState,
+                            onShowBottomSheetChange = { showCheckGroupMemberBottomSheet = it },
+                            memberList = it
+                        )
                     }
-                )
-            }
-            InfoCategoryScreen(
-                title = title,
-                type = type,
-                groupNumber = selectedGroupMembers.filter { it.selected }.size,
-                openSettingOption = if (!type) OpenSettings.GROUP else openSettingOption,
-                groupReader = "모카커피짱귀엽",
-                onTitleChanged = viewModel::setTitle,
-                onShowOpenSettingsBottomSheetChange = {
-                    showOpenSettingsBottomSheet = it
-                },
-                onGroupMemberChooseClicked = navigateToGroupMemberChoose,
-                onShowCheckGroupMemberBottomSheetChange = {
-                    showCheckGroupMemberBottomSheet = it
-                },
-                isGroupReader = isGroupReader,
-                onGroupDeleteClicked = { groupDeleteDialogVisible = true },
-                onGroupOutClicked = { groupOutDialogVisible = true }
-            )
-            if (groupDeleteDialogVisible) {
-                GroupDeleteFirstDialog(
-                    onConfirmation = { },
-                    onDismissRequest = { groupDeleteDialogVisible = false }
-                )
-            }
-            if (groupOutDialogVisible) {
-                GroupOutDialog(
-                    groupName = title,
-                    onAllDeleteClicked = { /*TODO*/ },
-                    onIncompletedTodoDeleteClicked = { /*TODO*/ },
-                    onNoDeleteClicked = { /*TODO*/ },
-                    onDismissRequest = { groupOutDialogVisible = it }
+                }
+                if (showOpenSettingsBottomSheet) {
+                    OpenSettingsBottomSheet(
+                        title = stringResource(id = R.string.title_open_settings),
+                        sheetState = openSettingsOptionSheetState,
+                        openSettingOption = category!!.openSettings,
+                        onShowBottomSheetChange = { showOpenSettingsBottomSheet = it },
+                        onOkButtonClicked = {
+                            viewModel.setOpenSettingOption(it)
+                            scope.launch { openSettingsOptionSheetState.hide() }
+                                .invokeOnCompletion {
+                                    if (!openSettingsOptionSheetState.isVisible) {
+                                        showOpenSettingsBottomSheet = false
+                                    }
+                                }
+                        }
+                    )
+                }
+                if (groupDeleteFirstDialogVisible) {
+                    GroupDeleteFirstDialog(
+                        onConfirmation = {
+                            groupDeleteFirstDialogVisible = false
+                            groupDeleteSecondDialogVisible = true
+                        },
+                        onDismissRequest = { groupDeleteFirstDialogVisible = false }
+                    )
+                }
+                if (groupDeleteSecondDialogVisible) {
+                    GroupDeleteSecondDialog(
+                        groupName = category!!.title,
+                        enabled = deleteDialogInputText == category!!.title.getNoSpace(),
+                        value = deleteDialogInputText,
+                        onValueChange = { deleteDialogInputText = it },
+                        onConfirmation = { /*TODO: 그룹 카테고리 삭제 로직*/ },
+                        onDismissRequest = { groupDeleteSecondDialogVisible = false })
+                }
+                if (groupOutDialogVisible) {
+                    CategoryOutDialog(
+                        title = stringResource(id = R.string.title_group_out),
+                        content = stringResource(
+                            id = R.string.content_group_out_message,
+                            category!!.title
+                        ),
+                        onAllDeleteClicked = { /*TODO: 그룹 카테고리 할 일 모두 삭제 로직*/ },
+                        onIncompletedTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                        onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ },
+                        onDismissRequest = { groupOutDialogVisible = false }
+                    )
+                }
+                if (normalOutDialogVisible) {
+                    CategoryOutDialog(
+                        title = stringResource(id = R.string.title_category_delete),
+                        content = stringResource(id = R.string.content_category_delete_message),
+                        onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
+                        onIncompletedTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                        onNoDeleteClicked = { /*TODO: 일반 카테고리 할 일은 삭제 안하는 로직*/ },
+                        onDismissRequest = { normalOutDialogVisible = false })
+                }
+                InfoCategoryScreen(
+                    title = category!!.title,
+                    type = category!!.type,
+                    groupNumber = selectedGroupMembers.filter { it.selected }.size,
+                    openSettingOption = if (category!!.type == CategoryType.GROUP) OpenSettings.GROUP else category!!.openSettings,
+                    groupReader = category!!.groupReader,
+                    onTitleChanged = viewModel::setTitle,
+                    onShowOpenSettingsBottomSheetChange = {
+                        showOpenSettingsBottomSheet = it
+                    },
+                    onGroupMemberChooseClicked = {
+                        navigateToGroupMemberChoose(
+                            MainNavigationDestination.InfoCategory.name
+                        )
+                    },
+                    onShowCheckGroupMemberBottomSheetChange = {
+                        showCheckGroupMemberBottomSheet = it
+                    },
+                    isGroupReader = category!!.isGroupReader,
+                    onGroupDeleteClicked = { groupDeleteFirstDialogVisible = true },
+                    onGroupOutClicked = { groupOutDialogVisible = true },
+                    onNormalDeletedClicked = { normalOutDialogVisible = true }
                 )
             }
         }
@@ -158,17 +199,18 @@ fun InfoCategoryScreenRoute(
 @Composable
 fun InfoCategoryScreen(
     title: String,
-    type: Boolean,
+    type: CategoryType,
     groupNumber: Int,
     onTitleChanged: (String) -> Unit,
     openSettingOption: OpenSettings,
     groupReader: String? = null,
-    isGroupReader: Boolean,
+    isGroupReader: Boolean?,
     onShowOpenSettingsBottomSheetChange: (Boolean) -> Unit,
     onGroupMemberChooseClicked: () -> Unit,
     onShowCheckGroupMemberBottomSheetChange: (Boolean) -> Unit,
     onGroupOutClicked: () -> Unit,
     onGroupDeleteClicked: () -> Unit,
+    onNormalDeletedClicked: () -> Unit,
 ) {
     val textFieldColors = TextFieldDefaults.colors(
         focusedTextColor = PomoroDoTheme.colorScheme.onBackground,
@@ -217,32 +259,32 @@ fun InfoCategoryScreen(
                 enabled = openSettingOption.enabled,
                 descriptionId = openSettingOption.descriptionId,
                 onClicked = { onShowOpenSettingsBottomSheetChange(true) },
-                isGroupInfo = !type
+                isGroupInfo = type == CategoryType.GROUP
             )
             HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)
-            if (type) {
+            if (type == CategoryType.NORMAL) {
                 CustomTextButton(
                     text = stringResource(id = R.string.content_do_delete),
                     containerColor = PomoroDoTheme.colorScheme.error50,
                     contentColor = Color.White,
                     textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
                     verticalPadding = 12.dp,
-                    onClick = {}
+                    onClick = onNormalDeletedClicked
                 )
             } else {
                 CategoryGroupNumber(
                     groupNumber = groupNumber,
                     onClicked = {
-                        if (isGroupReader) {
+                        if (isGroupReader == true) {
                             onGroupMemberChooseClicked()
-                        } else {
+                        } else if (isGroupReader == false) {
                             onShowCheckGroupMemberBottomSheetChange(true)
                         }
                     },
                     isGroupReader = isGroupReader
                 )
                 HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)
-                if (isGroupReader) {
+                if (isGroupReader == true) {
                     Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                         CustomTextButton(
                             modifier = Modifier.weight(1f),
@@ -264,7 +306,7 @@ fun InfoCategoryScreen(
                             verticalPadding = 12.dp,
                         )
                     }
-                } else {
+                } else if (isGroupReader == false) {
                     CustomTextButton(
                         text = stringResource(id = R.string.content_group_out),
                         containerColor = Color.Unspecified,
@@ -301,7 +343,7 @@ private fun GroupReader(name: String) {
 }
 
 @Composable
-private fun CategoryType(type: Boolean) {
+private fun CategoryType(type: CategoryType) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
@@ -313,7 +355,7 @@ private fun CategoryType(type: Boolean) {
         )
         Spacer(modifier = Modifier.weight(1f))
         SimpleText(
-            textId = if (type) R.string.content_category_normal else R.string.content_category_group,
+            textId = if (type == CategoryType.NORMAL) R.string.content_category_normal else R.string.content_category_group,
             style = PomoroDoTheme.typography.laundryGothicRegular14,
             color = PomoroDoTheme.colorScheme.onBackground
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/AddCategoryViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/AddCategoryViewModel.kt
@@ -1,0 +1,61 @@
+package com.tico.pomorodo.ui.category.viewModel
+
+import androidx.lifecycle.ViewModel
+import com.tico.pomorodo.data.local.datasource.DataSource
+import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.OpenSettings
+import com.tico.pomorodo.data.model.SelectedUser
+import com.tico.pomorodo.ui.common.view.toSelectedUser
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class AddCategoryViewModel @Inject constructor() : ViewModel() {
+
+    private var _title = MutableStateFlow("")
+    val title: StateFlow<String>
+        get() = _title.asStateFlow()
+
+    private var _type = MutableStateFlow(CategoryType.NORMAL)
+    val type: StateFlow<CategoryType>
+        get() = _type.asStateFlow()
+
+    private var _openSettingOption = MutableStateFlow(OpenSettings.FULL)
+    val openSettingOption: StateFlow<OpenSettings>
+        get() = _openSettingOption.asStateFlow()
+
+    private var _selectedGroupMembers =
+        MutableStateFlow<List<SelectedUser>>(listOf())
+    val selectedGroupMembers: StateFlow<List<SelectedUser>>
+        get() = _selectedGroupMembers.asStateFlow()
+
+    init {
+        fetchSelectedGroupMembers()
+    }
+
+    fun setOpenSettingOption(newOption: OpenSettings) {
+        _openSettingOption.value = newOption
+    }
+
+    fun setTitle(title: String) {
+        _title.value = title
+    }
+
+    fun setType(type: CategoryType) {
+        _type.value = type
+    }
+
+    fun setSelectedGroupMembers(newList: List<SelectedUser>) {
+        _selectedGroupMembers.value = newList
+    }
+
+    fun validateInput(): Boolean =
+        if (type.value == CategoryType.NORMAL) title.value.isNotBlank() else title.value.isNotBlank() && selectedGroupMembers.value.any { it.selected }
+
+    private fun fetchSelectedGroupMembers() {
+        _selectedGroupMembers.value = DataSource.userList.map { it.toSelectedUser() }
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryViewModel.kt
@@ -4,10 +4,6 @@ import androidx.lifecycle.ViewModel
 import com.tico.pomorodo.data.local.datasource.DataSource
 import com.tico.pomorodo.data.model.Category
 import com.tico.pomorodo.data.model.InviteCategory
-import com.tico.pomorodo.data.model.OpenSettings
-import com.tico.pomorodo.data.model.SelectedUser
-import com.tico.pomorodo.data.model.User
-import com.tico.pomorodo.ui.common.view.toSelectedUser
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,43 +17,4 @@ class CategoryViewModel : ViewModel() {
     private var _inviteGroupCategoryList = MutableStateFlow(DataSource.inviteList)
     val inviteGroupCategoryList: StateFlow<List<InviteCategory>>
         get() = _inviteGroupCategoryList.asStateFlow()
-
-    private var _openSettingOption = MutableStateFlow(OpenSettings.FULL)
-    val openSettingOption: StateFlow<OpenSettings>
-        get() = _openSettingOption.asStateFlow()
-
-    private var _title = MutableStateFlow("")
-    val title: StateFlow<String>
-        get() = _title.asStateFlow()
-
-    private var _type = MutableStateFlow(false)
-    val type: StateFlow<Boolean>
-        get() = _type.asStateFlow()
-
-    private var _groupMembers = MutableStateFlow<List<User>>(DataSource.userList)
-    val groupMembers: StateFlow<List<User>>
-        get() = _groupMembers.asStateFlow()
-
-    private var _selectedGroupMembers =
-        MutableStateFlow<List<SelectedUser>>(groupMembers.value.map { it.toSelectedUser() })
-    val selectedGroupMembers: StateFlow<List<SelectedUser>>
-        get() = _selectedGroupMembers.asStateFlow()
-
-    fun setOpenSettingOption(newOption: OpenSettings) {
-        _openSettingOption.value = newOption
-    }
-
-    fun setTitle(title: String) {
-        _title.value = title
-    }
-
-    fun setType(type: Boolean) {
-        _type.value = type
-    }
-
-    fun setSelectedGroupMembers(newList: List<SelectedUser>) {
-        _selectedGroupMembers.value = newList
-    }
-
-    fun validateInput(): Boolean = title.value.isNotBlank()
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/InfoCategoryViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/InfoCategoryViewModel.kt
@@ -1,0 +1,89 @@
+package com.tico.pomorodo.ui.category.viewModel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.tico.pomorodo.data.local.datasource.DataSource
+import com.tico.pomorodo.data.model.Category
+import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.OpenSettings
+import com.tico.pomorodo.data.model.SelectedUser
+import com.tico.pomorodo.data.model.User
+import com.tico.pomorodo.navigation.CategoryArgs
+import com.tico.pomorodo.ui.common.view.toSelectedUser
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class InfoCategoryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val args = CategoryArgs(savedStateHandle)
+
+    private var _category = MutableStateFlow<Category?>(null)
+    val category: StateFlow<Category?>
+        get() = _category.asStateFlow()
+
+    private var _selectedGroupMembers =
+        MutableStateFlow<List<SelectedUser>>(listOf())
+    val selectedGroupMembers: StateFlow<List<SelectedUser>>
+        get() = _selectedGroupMembers.asStateFlow()
+
+    private var follower = MutableStateFlow<List<User>?>(null)
+
+    init {
+        fetchCategoryInfo(args.categoryId)
+        fetchFollower()
+        fetchSelectedGroupMembers()
+    }
+
+    fun setOpenSettingOption(newOption: OpenSettings) {
+        _category.value = category.value?.copy(openSettings = newOption)
+    }
+
+    fun setTitle(title: String) {
+        _category.value = category.value?.copy(title = title)
+    }
+
+    fun setSelectedGroupMembers(newList: List<SelectedUser>) {
+        _selectedGroupMembers.value = newList
+    }
+
+    fun validateInput(): Boolean {
+        category.value?.let { category ->
+            if (category.type == CategoryType.NORMAL) {
+                return category.title.isNotBlank()
+            } else {
+                return category.title.isNotBlank() && selectedGroupMembers.value.any { it.selected }
+            }
+        }
+        return false
+    }
+
+    private fun fetchCategoryInfo(categoryId: String) {
+        _category.value = DataSource.categoryList[categoryId.toInt() - 1]
+    }
+
+    private fun fetchFollower() {
+        follower.value = DataSource.userList
+    }
+
+    private fun fetchSelectedGroupMembers() {
+        val categoryValue = category.value
+        val followerValue = follower.value
+
+        if (categoryValue != null && followerValue != null) {
+            val groupMembers = categoryValue.groupMember
+
+            if (groupMembers != null) {
+                _selectedGroupMembers.value = followerValue.map { user ->
+                    val isSelected = groupMembers.any { it.id == user.id }
+                    user.toSelectedUser(selected = isSelected)
+                }
+            }
+        }
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Extensions.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Extensions.kt
@@ -3,20 +3,33 @@ package com.tico.pomorodo.ui.common.view
 import android.content.Context
 import android.widget.Toast
 import androidx.annotation.StringRes
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ripple
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import com.tico.pomorodo.data.model.SelectedUser
 import com.tico.pomorodo.data.model.User
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import java.io.File
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
@@ -104,4 +117,31 @@ fun Context.createImageFile(): File {
 
 fun Context.executeToast(@StringRes messageId: Int) {
     Toast.makeText(this, this.getString(messageId), Toast.LENGTH_SHORT).show()
+}
+
+fun Modifier.shimmerEffect(): Modifier = composed {
+    var size by remember {
+        mutableStateOf(IntSize.Zero)
+    }
+    val transition = rememberInfiniteTransition(label = "")
+    val startOffset by transition.animateFloat(
+        initialValue = -2 * size.width.toFloat(),
+        targetValue = 2 * size.width.toFloat(),
+        animationSpec = infiniteRepeatable(animation = tween(1000)), label = ""
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                PomoroDoTheme.colorScheme.gray70,
+                PomoroDoTheme.colorScheme.gray50,
+                PomoroDoTheme.colorScheme.gray70
+            ),
+            start = Offset(startOffset, 0f),
+            end = Offset(startOffset + size.width.toFloat(), size.height.toFloat())
+        )
+    )
+        .onGloballyPositioned {
+            size = it.size
+        }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -122,6 +123,37 @@ fun CategoryTag(
             Image(
                 imageVector = PomoroDoTheme.iconPack[IC_ADD_TODO]!!,
                 contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+fun CategoryTag(
+    title: String,
+    groupNumber: Int
+) {
+    Row(
+        modifier = Modifier
+            .background(
+                PomoroDoTheme.colorScheme.secondaryContainer, RoundedCornerShape(5.dp)
+            )
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        SimpleText(
+            modifier = Modifier,
+            text = title,
+            style = PomoroDoTheme.typography.laundryGothicRegular14,
+            color = PomoroDoTheme.colorScheme.secondary
+        )
+        if (groupNumber > 0) {
+            SimpleText(
+                modifier = Modifier,
+                text = stringResource(id = R.string.content_add_todo_group_number, groupNumber),
+                style = PomoroDoTheme.typography.laundryGothicRegular14,
+                color = PomoroDoTheme.colorScheme.secondary
             )
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
@@ -88,21 +88,28 @@ fun TodoScreen(
                         )
                     }
                     Spacer(modifier = Modifier.height(5.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
-                        repeat(categoryList[categoryIndex].todoList.size) { itemIndex ->
-                            TodoListItem(
-                                todoData = categoryList[categoryIndex].todoList[itemIndex],
-                                isGroup = categoryList[categoryIndex].groupNumber > 0,
-                                onStateChanged = {
-                                    onTodoStateChanged(categoryIndex, itemIndex, categoryList[categoryIndex].todoList[itemIndex].state)
-                                },
-                                onMoreInfoEditClicked = {},
-                                onMoreInfoDeleteClicked = {},
-                                isFriend = selectedProfileIndex != -1,
-                                onGroupClicked = { onGroupClicked(categoryIndex, itemIndex) },
-                                onLikedClicked = {}
-                            )
+                    categoryList[categoryIndex].todoList?.let { todoList ->
+                        Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                            repeat(todoList.size) { itemIndex ->
+                                TodoListItem(
+                                    todoData = todoList[itemIndex],
+                                    isGroup = categoryList[categoryIndex].groupNumber > 0,
+                                    onStateChanged = {
+                                        onTodoStateChanged(
+                                            categoryIndex,
+                                            itemIndex,
+                                            todoList[itemIndex].state
+                                        )
+                                    },
+                                    onMoreInfoEditClicked = {},
+                                    onMoreInfoDeleteClicked = {},
+                                    isFriend = selectedProfileIndex != -1,
+                                    onGroupClicked = { onGroupClicked(categoryIndex, itemIndex) },
+                                    onLikedClicked = {}
+                                )
+                            }
                         }
+
                     }
                     Spacer(modifier = Modifier.height(16.dp))
                 }
@@ -148,15 +155,18 @@ fun TodoScreenRoute(
                 onManageCategoryClicked = navigateToCategory,
                 onAddCategoryClicked = navigateToAddCategory
             )
-            if (showGroupBottomSheet) {
-                GroupBottomSheet(
-                    title = categoryList[selectedCategoryGroupIndex].todoList[selectedGroupItemIndex].name,
-                    sheetState = sheetState,
-                    onShowBottomSheetChange = { showGroupBottomSheet = it },
-                    completedList = DataSource.userList,
-                    incompletedList = DataSource.userList,
-                    totalNumber = 5,
-                )
+            if (showGroupBottomSheet && selectedCategoryGroupIndex != -1 && selectedGroupItemIndex != -1) {
+                categoryList[selectedCategoryGroupIndex].todoList?.get(selectedGroupItemIndex)
+                    ?.let { todo ->
+                        GroupBottomSheet(
+                            title = todo.name,
+                            sheetState = sheetState,
+                            onShowBottomSheetChange = { showGroupBottomSheet = it },
+                            completedList = DataSource.userList,
+                            incompletedList = DataSource.userList,
+                            totalNumber = categoryList[selectedCategoryGroupIndex].groupNumber,
+                        )
+                    }
             }
             TodoScreen(
                 selectedProfileIndex = selectedProfileIndex,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
@@ -62,11 +62,13 @@ class TodoViewModel() : ViewModel() {
                 completeGroupNumber = 0
             )
             val newList = categoryList.value.toMutableList()
-            val newTodoList = newList[selectedCategoryIndex.value].todoList.toMutableList()
-            newTodoList.add(0, newTodoData)
-            newList[selectedCategoryIndex.value] =
-                newList[selectedCategoryIndex.value].copy(todoList = newTodoList)
-            _categoryList.value = newList
+            if (selectedCategoryIndex.value != -1) {
+                val newTodoList = newList[selectedCategoryIndex.value].todoList?.toMutableList()
+                newTodoList?.add(0, newTodoData)
+                newList[selectedCategoryIndex.value] =
+                    newList[selectedCategoryIndex.value].copy(todoList = newTodoList)
+                _categoryList.value = newList
+            }
         }
         _todoMakeVisible.value = false
         _selectedCategoryIndex.value = -1
@@ -80,11 +82,13 @@ class TodoViewModel() : ViewModel() {
             TodoState.GOING -> TodoState.UNCHECKED
         }
         val newList = categoryList.value.toMutableList()
-        val newTodoList = newList[categoryIndex].todoList.toMutableList()
-        val newItem = newTodoList[todoIndex].copy(state = newState)
-        newTodoList[todoIndex] = newItem
-        newList[categoryIndex] = newList[categoryIndex].copy(todoList = newTodoList)
-        _categoryList.value = newList
+        newList[categoryIndex].todoList?.let { newListTodo ->
+            val newTodoList = newListTodo.toMutableList()
+            val newItem = newTodoList[todoIndex].copy(state = newState)
+            newTodoList[todoIndex] = newItem
+            newList[categoryIndex] = newList[categoryIndex].copy(todoList = newTodoList)
+            _categoryList.value = newList
+        }
     }
 
     private fun validateTodoInput(inputText: String): Boolean {

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="content_group_delete_placehold">그룹 이름을 따라 입력하세요.</string>
     <string name="content_group_delete_first_message">그룹을 삭제하시겠습니까?\n모든 그룹원들의 할 일이 모두 삭제됩니다.</string>
     <string name="content_do_delete">삭제하기</string>
+    <string name="title_category_delete">카테고리 삭제</string>
+    <string name="content_category_delete_message">카테고리를 삭제합니다.\n기존 할 일을 삭제하시겠습니까?</string>
 
     // history
     <string name="title_history">기록</string>


### PR DESCRIPTION
**변경 사항**
- UI 보충 작업
  - cateogry 정보 확인에서 categoryId를 navigation argument로 전달하고, savedStateHandle로 저장 및 가져 옴
  - 그룹원 선택 화면을 info 화면과 add 화면에 따라 다른 viewModel을 적용
  - 투두에서 데이터 연결하지 않은 부분 보충
- 그룹 나가기 다이얼로그를 공용으로 사용할 수 있게 변경
- Category 데이터 변수 추가 및 임시 데이터 변경
- CategoryViewModel을 각 화면에 따라 분리
  - AddCategoryViewModel
  - InfoCategoryViewModel
- 카테고리 관리 화면에서 카테고리를 클릭시 정보로 들어가지 않는 문제 해결
  -  이중 클릭 함수로 카테고리 태그에 클릭 함수가 적용되지않아서 오버라이딩으로 새로운 카테고리 태그 컴포저블 생성
- 카테고리 추가 화면 보충
  - 공개설정의 그룹 설명을 그룹 카테고리일 때만 보이게 설정
  - 유형에서 글자를 눌러도 라디오 버튼이 변경되게 변경
 
---

**추가 사항**
- loading을 위한 skeleton extensions 추가
- string 리소스 추가


Fixes: TICO-204