### PR TITLE
[FEAT] 로그인 및 회원가입 JWT 반환 로직 수정 (TICO-227)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -2,7 +2,7 @@ package com.tico.pomoro_do.domain.user.controller;
 
 import com.tico.pomoro_do.domain.user.dto.request.AdminJoinDTO;
 import com.tico.pomoro_do.domain.user.dto.request.AdminLoginDTO;
-import com.tico.pomoro_do.domain.user.dto.response.JwtDTO;
+import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
 import com.tico.pomoro_do.domain.user.service.AdminService;
 import com.tico.pomoro_do.global.code.SuccessCode;
 import com.tico.pomoro_do.global.response.SuccessResponseDTO;
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,13 +36,14 @@ public class AdminController {
      * 관리자 회원가입 API
      *
      * @param request AdminJoinDTO 객체
-     * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
+     * @param response HttpServletResponse 객체
+     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
      */
     @Operation(
             summary = "관리자 회원가입",
             description = "관리자 회원가입을 수행합니다. <br>"
                     + "관리자의 이메일은 @pomorodo.shop 도메인으로 제한됩니다. <br>"
-                    + "성공 시에는 JwtDTO를 포함하는 SuccessResponseDTO를 반환합니다.",
+                    + "성공 시에는 TokenDTO를 포함하는 SuccessResponseDTO를 반환합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "AdminJoinDTO 객체",
                     required = true,
@@ -56,28 +58,32 @@ public class AdminController {
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
     })
     @PostMapping("/join")
-    public ResponseEntity<SuccessResponseDTO<JwtDTO>> adminJoin(@RequestBody AdminJoinDTO request) {
+    public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminJoin(
+            @RequestBody AdminJoinDTO request,
+            HttpServletResponse response
+    ) {
         log.info("관리자 회원가입 요청: {}", request.getUsername());
-        JwtDTO jwtResponse = adminService.adminJoin(request);
-        SuccessResponseDTO<JwtDTO> response = SuccessResponseDTO.<JwtDTO>builder()
+        TokenDTO jwtResponse = adminService.adminJoin(request, response);
+        SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                 .status(SuccessCode.ADMIN_SIGNUP_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
                 .data(jwtResponse)
                 .build();
         log.info("관리자 회원가입 성공: {}", request.getUsername());
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
     }
 
     /**
      * 관리자 로그인 API
      *
      * @param request AdminLoginDTO 객체
-     * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
+     * @param response HttpServletResponse 객체
+     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
      */
     @Operation(
             summary = "관리자 로그인",
             description = "관리자 로그인을 수행합니다. <br>"
-                    + "성공 시에는 JwtDTO를 포함하는 SuccessResponseDTO를 반환합니다.",
+                    + "성공 시에는 TokenDTO를 포함하는 SuccessResponseDTO를 반환합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "AdminLoginDTO 객체",
                     required = true,
@@ -94,15 +100,18 @@ public class AdminController {
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
     })
     @PostMapping("/login")
-    public ResponseEntity<SuccessResponseDTO<JwtDTO>> adminLogin(@RequestBody AdminLoginDTO request) {
+    public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminLogin(
+            @RequestBody AdminLoginDTO request,
+            HttpServletResponse response
+    ) {
         log.info("관리자 로그인 요청: {}", request.getUsername());
-        JwtDTO jwtResponse = adminService.adminLogin(request);
-        SuccessResponseDTO<JwtDTO> response = SuccessResponseDTO.<JwtDTO>builder()
+        TokenDTO jwtResponse = adminService.adminLogin(request, response);
+        SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                 .status(SuccessCode.ADMIN_LOGIN_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_LOGIN_SUCCESS.getMessage())
                 .data(jwtResponse)
                 .build();
         log.info("관리자 로그인 성공: {}", request.getUsername());
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(successResponse);
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -52,6 +52,7 @@ public class AuthController {
      * 구글 로그인 API
      *
      * @param googleIdTokenHeader Google-ID-Token 헤더에 포함된 구글 ID 토큰
+     * @param response HttpServletResponse 객체
      * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
      * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
      */
@@ -76,17 +77,18 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
     })
     @PostMapping("/google/login")
-    public ResponseEntity<SuccessResponseDTO<JwtDTO>> googleLogin(
-            @RequestHeader("Google-ID-Token") String googleIdTokenHeader
+    public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleLogin(
+            @RequestHeader("Google-ID-Token") String googleIdTokenHeader,
+            HttpServletResponse response
     ) {
         try {
-            JwtDTO jwtResponse = authService.googleLogin(googleIdTokenHeader);
-            SuccessResponseDTO<JwtDTO> response = SuccessResponseDTO.<JwtDTO>builder()
+            TokenDTO jwtResponse = authService.googleLogin(googleIdTokenHeader, response);
+            SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                     .status(SuccessCode.GOOGLE_LOGIN_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_LOGIN_SUCCESS.getMessage())
                     .data(jwtResponse)
                     .build();
-            return ResponseEntity.ok(response);
+            return ResponseEntity.ok(successResponse);
         } catch (GeneralSecurityException | IOException | IllegalArgumentException e) {
             log.error("구글 ID 토큰 검증 실패: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.GOOGLE_TOKEN_VERIFICATION_FAILED);
@@ -98,6 +100,7 @@ public class AuthController {
      *
      * @param googleIdTokenHeader Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param requestUserInfo 회원가입 요청 정보가 포함된 DTO
+     * @param response HttpServletResponse 객체
      * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
      * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
      */
@@ -122,18 +125,19 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
     })
     @PostMapping("/google/join")
-    public ResponseEntity<SuccessResponseDTO<JwtDTO>> googleJoin(
+    public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleJoin(
             @RequestHeader("Google-ID-Token") String googleIdTokenHeader,
-            @Valid @RequestBody GoogleJoinDTO requestUserInfo
+            @Valid @RequestBody GoogleJoinDTO requestUserInfo,
+            HttpServletResponse response
     ) {
         try {
-            JwtDTO jwtResponse = authService.googleJoin(googleIdTokenHeader, requestUserInfo);
-            SuccessResponseDTO<JwtDTO> response = SuccessResponseDTO.<JwtDTO>builder()
+            TokenDTO jwtResponse = authService.googleJoin(googleIdTokenHeader, requestUserInfo, response);
+            SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                     .status(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getMessage())
                     .data(jwtResponse)
                     .build();
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+            return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
         } catch (GeneralSecurityException | IOException | IllegalArgumentException e) {
             log.error("구글 ID 토큰 검증 실패: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.GOOGLE_TOKEN_VERIFICATION_FAILED);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
@@ -3,12 +3,14 @@ package com.tico.pomoro_do.domain.user.service;
 import com.tico.pomoro_do.domain.user.dto.request.AdminJoinDTO;
 import com.tico.pomoro_do.domain.user.dto.request.AdminLoginDTO;
 import com.tico.pomoro_do.domain.user.dto.response.JwtDTO;
+import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AdminService {
 
     //관리자 회원가입
-    JwtDTO adminJoin(AdminJoinDTO adminJoinDTO);
+    TokenDTO adminJoin(AdminJoinDTO adminJoinDTO, HttpServletResponse response);
 
     //관리자 로그인
-    JwtDTO adminLogin(AdminLoginDTO adminLoginDTO);
+    TokenDTO adminLogin(AdminLoginDTO adminLoginDTO, HttpServletResponse response);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
@@ -3,11 +3,13 @@ package com.tico.pomoro_do.domain.user.service;
 import com.tico.pomoro_do.domain.user.dto.request.AdminJoinDTO;
 import com.tico.pomoro_do.domain.user.dto.request.AdminLoginDTO;
 import com.tico.pomoro_do.domain.user.dto.response.JwtDTO;
+import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.domain.user.repository.UserRepository;
 import com.tico.pomoro_do.global.enums.UserRole;
 import com.tico.pomoro_do.global.code.ErrorCode;
 import com.tico.pomoro_do.global.exception.CustomException;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,12 +32,13 @@ public class AdminServiceImpl implements AdminService {
      * 관리자 회원가입 처리
      *
      * @param adminJoinDTO AdminJoinDTO 객체
-     * @return JwtDTO를 포함하는 ResponseEntity
-     * @throws CustomException 이메일 도메인이 유효하지 않거나 이미 등록된 사용자인 경우 예외
+     * @param response HttpServletResponse 객체
+     * @return 성공 시 JwtDTO를 포함하는 TokenDTO 객체
+     * @throws CustomException 이메일 도메인이 유효하지 않거나 이미 등록된 사용자인 경우 예외를 던집니다.
      */
     @Override
     @Transactional
-    public JwtDTO adminJoin(AdminJoinDTO adminJoinDTO) {
+    public TokenDTO adminJoin(AdminJoinDTO adminJoinDTO, HttpServletResponse response) {
         String username = adminJoinDTO.getUsername();
         String nickname = adminJoinDTO.getNickname();
 
@@ -49,18 +52,20 @@ public class AdminServiceImpl implements AdminService {
         // 관리자 생성하기
         User admin = authService.createUser(username, nickname, "", UserRole.ADMIN);
 
-        return authService.createJwtTokens(username, String.valueOf(UserRole.ADMIN));
+        return authService.generateAndStoreTokens(username, String.valueOf(UserRole.ADMIN), response);
     }
 
     /**
      * 관리자 로그인 처리
      *
      * @param adminLoginDTO AdminLoginDTO 객체
-     * @return JwtDTO를 포함하는 ResponseEntity
-     * @throws CustomException 이메일 도메인이 유효하지 않거나 관리자가 아닌 경우 예외
+     * @param response HttpServletResponse 객체
+     * @return 성공 시 JwtDTO를 포함하는 TokenDTO 객체
+     * @throws CustomException 이메일 도메인이 유효하지 않거나 관리자가 아닌 경우 예외를 던집니다.
      */
     @Override
-    public JwtDTO adminLogin(AdminLoginDTO adminLoginDTO){
+    @Transactional
+    public TokenDTO adminLogin(AdminLoginDTO adminLoginDTO, HttpServletResponse response){
         String username = adminLoginDTO.getUsername();
         String nickname = adminLoginDTO.getNickname();
 
@@ -70,7 +75,7 @@ public class AdminServiceImpl implements AdminService {
         validateAdminEmailDomain(domain);
         // 관리자 로그인 검증
         validateAdminUser(username, nickname);
-        return authService.createJwtTokens(username, String.valueOf(UserRole.ADMIN));
+        return authService.generateAndStoreTokens(username, String.valueOf(UserRole.ADMIN), response);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -23,16 +23,16 @@ public interface AuthService {
     String extractToken(String header, TokenType tokenType);
 
     // 구글 로그인
-    JwtDTO googleLogin(String idTokenHeader) throws GeneralSecurityException, IOException;
+    TokenDTO googleLogin(String idTokenHeader, HttpServletResponse response) throws GeneralSecurityException, IOException;
 
     // 구글 회원가입
-    JwtDTO googleJoin(String idTokenHeader, GoogleJoinDTO request)  throws GeneralSecurityException, IOException;
+    TokenDTO googleJoin(String idTokenHeader, GoogleJoinDTO request, HttpServletResponse response)  throws GeneralSecurityException, IOException;
 
     // User 생성
     User createUser(String username, String nickname, String profileImageUrl, UserRole role);
 
     // 토큰 생성
-    JwtDTO createJwtTokens(String email, String role);
+    TokenDTO generateAndStoreTokens(String username, String role, HttpServletResponse response);
 
     // Refresh 토큰으로 Access토큰 발급
     TokenDTO reissueToken(HttpServletRequest request, HttpServletResponse response);


### PR DESCRIPTION
- 액세스 토큰만 반환하도록 JWT 반환 방식 변경
- Refresh 토큰을 데이터베이스에 저장하고 쿠키로 응답에 추가

Ref: TICO-180
Related to: TICO-206, TICO-164, TICO-162