### PR TITLE
[FEAT] 토큰 재발행 API 로직 변경 (TICO-241)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
@@ -12,6 +12,8 @@ public interface RefreshRepository extends JpaRepository<Refresh, Long> {
     boolean existsByRefreshToken(String refreshToken);
     Optional<Refresh> findByDeviceId(String deviceId);
 
+    Optional<Refresh> findByRefreshToken(String refreshToken);
+
 
     // 해당 리프레쉬 토큰을 삭제하는 메소드
     @Transactional

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
@@ -4,10 +4,14 @@ import com.tico.pomoro_do.domain.user.entity.Refresh;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
 
     // 해당 리프레쉬 토큰의 존재 여부를 판단하는 메소드
-    Boolean existsByRefreshToken(String refreshToken);
+    boolean existsByRefreshToken(String refreshToken);
+    Optional<Refresh> findByDeviceId(String deviceId);
+
 
     // 해당 리프레쉬 토큰을 삭제하는 메소드
     @Transactional
@@ -16,4 +20,8 @@ public interface RefreshRepository extends JpaRepository<Refresh, Long> {
     // 사용자 이름을 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
     @Transactional
     void deleteByUsername(String username);
+
+    // 디바이스 id를 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
+    @Transactional
+    void deleteByDeviceId(String deviceId);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -35,6 +35,6 @@ public interface AuthService {
     TokenDTO generateAndStoreTokens(String username, String role, HttpServletResponse response);
 
     // Refresh 토큰으로 Access토큰 발급
-    TokenDTO reissueToken(HttpServletRequest request, HttpServletResponse response);
+    TokenDTO reissueToken(String deviceId, String refresh);
 
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -245,20 +245,20 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public TokenDTO reissueToken(String deviceId, String refresh) {
-        log.info("Refresh 토큰으로 Access 토큰 재발급");
+        log.info("Refresh 토큰으로 Access 토큰 재발급 시도: deviceId = {}", deviceId);
 
         // 리프레시 토큰을 검증합니다.
-        log.info("Refresh 토큰 검증 시작");
+        log.info("Refresh 토큰 검증 시작: refreshToken = {}", refresh);
         tokenService.validateToken(refresh, "refresh");
         log.info("Refresh 토큰 검증 완료");
 
-        // DB에서 deviceId에 해당하는 리프레시 토큰 정보를 가져옵니다.
-        Refresh refreshEntity = tokenService.getRefreshEntityByDeviceId(deviceId);
+        // DB에서 리프레시 토큰에 해당하는 리프레시 토큰 정보를 가져옵니다.
+        Refresh refreshEntity = tokenService.getRefreshByRefreshToken(refresh);
 
-        // DB에 저장된 리프레시 토큰과 요청된 리프레시 토큰이 일치하는지 확인합니다.
-        if (!refreshEntity.getRefreshToken().equals(refresh)) {
-            log.error("리프레시 토큰이 DB에 존재하지 않음: refreshToken = {}", refresh);
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+        // DB에 저장된 deviceId와 요청된 deviceId이 일치하는지 확인합니다.
+        if (!refreshEntity.getDeviceId().equals(deviceId)) {
+            log.error("Device ID가 DB에 존재하지 않음: deviceId = {}", deviceId);
+            throw new CustomException(ErrorCode.DEVICE_ID_MISMATCH);
         }
 
         // 리프레시 토큰에서 사용자 정보를 추출합니다.
@@ -277,7 +277,7 @@ public class AuthServiceImpl implements AuthService {
         tokenService.addRefreshEntity(username, newRefresh, refreshExpiration, deviceId);
 
         // 새로운 액세스 토큰을 DTO로 반환합니다.
-        log.info("Access 토큰 재발급 완료");
+        log.info("Access 토큰 및 Refresh 토큰 재발급 완료: newAccessToken = {}, newRefreshToken = {}", newAccess, newRefresh);
         return new TokenDTO(newAccess);
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -10,7 +10,8 @@ public interface TokenService {
     void addRefreshEntity(String username, String refresh, Long expiredMs, String deviceId);
 
     // 토큰 가져오기
-    Refresh getRefreshEntityByDeviceId(String deviceId);
+    Refresh getRefreshByDeviceId(String deviceId);
+    Refresh getRefreshByRefreshToken(String refreshToken);
 
     // 토큰 검증
     void validateToken(String token, String expectedCategory);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -1,12 +1,16 @@
 package com.tico.pomoro_do.domain.user.service;
 
+import com.tico.pomoro_do.domain.user.entity.Refresh;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface TokenService {
 
     // 리프레쉬 토큰 저장
-    void addRefreshEntity(String username, String refresh, Long expiredMs);
+    void addRefreshEntity(String username, String refresh, Long expiredMs, String deviceId);
+
+    // 토큰 가져오기
+    Refresh getRefreshEntityByDeviceId(String deviceId);
 
     // 토큰 검증
     void validateToken(String token, String expectedCategory);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -37,7 +37,7 @@ public class TokenServiceImpl implements TokenService{
      */
     @Transactional
     @Override
-    public void addRefreshEntity(String username, String refresh, Long expiredMs) {
+    public void addRefreshEntity(String username, String refresh, Long expiredMs, String deviceId) {
 
         Date date = new Date(System.currentTimeMillis() + expiredMs);
 
@@ -45,11 +45,28 @@ public class TokenServiceImpl implements TokenService{
                 .username(username)
                 .refreshToken(refresh)
                 .expiration(date.toString())
+                .deviceId(deviceId)
                 .build();
 
         refreshRepository.save(refreshEntity);
         log.info("리프레시 토큰 저장 성공: 사용자 = {}, 토큰 = {}", username, refresh);
 
+    }
+
+    /**
+     * 주어진 deviceId로 리프레시 토큰 엔티티를 가져옵니다.
+     *
+     * @param deviceId 기기 고유 번호
+     * @return Refresh 엔티티
+     * @throws CustomException 기기 ID가 DB에 존재하지 않을 때 발생하는 예외
+     */
+    @Override
+    public Refresh getRefreshEntityByDeviceId(String deviceId) {
+        return refreshRepository.findByDeviceId(deviceId)
+                .orElseThrow(() -> {
+                    log.error("Device ID가 DB에 존재하지 않음: deviceId = {}", deviceId);
+                    return new CustomException(ErrorCode.DEVICE_ID_NOT_FOUND);
+                });
     }
 
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -61,7 +61,7 @@ public class TokenServiceImpl implements TokenService{
      * @throws CustomException 기기 ID가 DB에 존재하지 않을 때 발생하는 예외
      */
     @Override
-    public Refresh getRefreshEntityByDeviceId(String deviceId) {
+    public Refresh getRefreshByDeviceId(String deviceId) {
         return refreshRepository.findByDeviceId(deviceId)
                 .orElseThrow(() -> {
                     log.error("Device ID가 DB에 존재하지 않음: deviceId = {}", deviceId);
@@ -69,6 +69,21 @@ public class TokenServiceImpl implements TokenService{
                 });
     }
 
+    /**
+     * 주어진 리프레시 토큰으로 리프레시 토큰 엔티티를 가져옵니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return Refresh 엔티티
+     * @throws CustomException 리프레시 토큰이 DB에 존재하지 않을 때 발생하는 예외
+     */
+    @Override
+    public Refresh getRefreshByRefreshToken(String refreshToken) {
+        return refreshRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> {
+                    log.error("리프레시 토큰이 DB에 존재하지 않음: refreshToken = {}", refreshToken);
+                    return new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                });
+    }
 
     /**
      * 주어진 토큰을 검증

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
@@ -75,7 +75,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiration); //24시간
 
         //Refresh 토큰 저장
-        tokenService.addRefreshEntity(username, refresh, refreshExpiration);
+        String deviceId = request.getHeader("Device-Id");
+        tokenService.addRefreshEntity(username, refresh, refreshExpiration, deviceId);
 
         //응답 설정
         //access 토큰 헤더에 넣어서 응답 (key: value 형태) -> 예시) access: 인증토큰(string)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
@@ -106,6 +106,7 @@ public enum ErrorCode {
     MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "T-206", "리프레시 토큰이 제공되지 않았습니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, "T-207", "Authorization 헤더의 토큰이 유효하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "T-208", "제공된 리프레시 토큰과 서버의 토큰이 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "T-209", "제공된 리프레시 토큰이 서버에 존재하지 않습니다."),
 
     // JWT 검증 관련 에러 - 230번대
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "T-231", "JWT 서명 검증에 실패했습니다."),
@@ -120,6 +121,7 @@ public enum ErrorCode {
     // 기기 관련 에러 - 300번대
     DEVICE_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "D-300", "제공된 Device ID가 서버에 존재하지 않습니다."),
     INVALID_DEVICE_ID_HEADER(HttpStatus.BAD_REQUEST, "D-301", "Device ID 헤더의 값이 유효하지 않습니다."),
+    DEVICE_ID_MISMATCH(HttpStatus.BAD_REQUEST, "D-302", "제공된 Device ID와 서버의 Device ID가 일치하지 않습니다."),
 
     // 관리자 관련 에러: -400번대
     NOT_AN_ADMIN(HttpStatus.FORBIDDEN, "A-400", "관리자 권한이 없습니다."),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
@@ -102,21 +102,26 @@ public enum ErrorCode {
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "T-202", "리프레시 토큰이 만료되었습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.FORBIDDEN, "T-203", "액세스 토큰이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "T-204", "리프레시 토큰이 유효하지 않습니다."),
-    MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "T-205", "액세스 토큰이 없습니다."),
-    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "T-206", "리프레시 토큰이 없습니다."),
-    MISSING_REFRESH_TOKEN_IN_DB(HttpStatus.BAD_REQUEST, "T-207", "DB에 해당 리프레시 토큰이 없습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "T-208", "서버의 리프레시 토큰과 일치하지 않습니다."),
-    INVALID_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, "T-209", "AUTHORIZATION 헤더의 토큰이 유효하지 않습니다."),
-    // JWT 서명 오류
-    INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "T-211", "JWT 서명 검증에 실패했습니다."),
-    // 잘못된 JWT 형식
-    INVALID_MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "T-212", "잘못된 JWT 토큰입니다."),
+    MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "T-205", "액세스 토큰이 제공되지 않았습니다."),
+    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "T-206", "리프레시 토큰이 제공되지 않았습니다."),
+    INVALID_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, "T-207", "Authorization 헤더의 토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "T-208", "제공된 리프레시 토큰과 서버의 토큰이 일치하지 않습니다."),
 
-    //구글 토큰 관련 에러: -300번대
-    GOOGLE_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "GT-300", "구글 ID 토큰 검증에 실패했습니다."),
-    INVALID_GOOGLE_TOKEN_HEADER(HttpStatus.BAD_REQUEST, "GT-301", "GOOGLE_ID_TOKEN 헤더의 토큰이 유효하지 않습니다."),
+    // JWT 검증 관련 에러 - 230번대
+    INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "T-231", "JWT 서명 검증에 실패했습니다."),
+    INVALID_MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "T-232", "잘못된 형식의 JWT입니다."),
+    UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "T-233", "지원하지 않는 JWT입니다."),
+    ILLEGAL_ARGUMENT(HttpStatus.UNAUTHORIZED, "T-234", "잘못된 JWT 토큰입니다."),
 
-    //관리자 관련 에러: -400번대
+    // 구글 토큰 관련 에러 - 290번대
+    GOOGLE_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "T-290", "구글 ID 토큰 검증에 실패했습니다."),
+    INVALID_GOOGLE_TOKEN_HEADER(HttpStatus.BAD_REQUEST, "T-291", "Google ID Token 헤더가 유효하지 않습니다."),
+
+    // 기기 관련 에러 - 300번대
+    DEVICE_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "D-300", "제공된 Device ID가 서버에 존재하지 않습니다."),
+    INVALID_DEVICE_ID_HEADER(HttpStatus.BAD_REQUEST, "D-301", "Device ID 헤더의 값이 유효하지 않습니다."),
+
+    // 관리자 관련 에러: -400번대
     NOT_AN_ADMIN(HttpStatus.FORBIDDEN, "A-400", "관리자 권한이 없습니다."),
     INVALID_ADMIN_EMAIL(HttpStatus.BAD_REQUEST, "A-401", "허용되지 않은 관리자 이메일입니다."),
     ADMIN_EMAIL_ONLY(HttpStatus.FORBIDDEN, "A-402", "관리자 이메일만 접근할 수 있습니다."),


### PR DESCRIPTION
- 토큰 검증 함수 에러 처리 세분화 및 로그 개선
- 기기의 고유번호를 헤더로 받아 DB 확인 작업을 통해 리프레시 토큰 검증
- 리프레시 토큰을 기준으로  리프레시 Entity를 조회하도록 로직 변경

Related to: TICO-206