### PR TITLE
[FEAT] 관리자 회원가입 및 로그인 API 로직 변경 (TICO-244)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,7 +35,6 @@ public class AdminController {
      * 관리자 회원가입 API
      *
      * @param request AdminJoinDTO 객체
-     * @param response HttpServletResponse 객체
      * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
      */
     @Operation(
@@ -59,11 +57,10 @@ public class AdminController {
     })
     @PostMapping("/join")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminJoin(
-            @RequestBody AdminJoinDTO request,
-            HttpServletResponse response
+            @RequestBody AdminJoinDTO request
     ) {
         log.info("관리자 회원가입 요청: {}", request.getUsername());
-        TokenDTO jwtResponse = adminService.adminJoin(request, response);
+        TokenDTO jwtResponse = adminService.adminJoin(request);
         SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                 .status(SuccessCode.ADMIN_SIGNUP_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
@@ -77,7 +74,6 @@ public class AdminController {
      * 관리자 로그인 API
      *
      * @param request AdminLoginDTO 객체
-     * @param response HttpServletResponse 객체
      * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
      */
     @Operation(
@@ -101,11 +97,10 @@ public class AdminController {
     })
     @PostMapping("/login")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminLogin(
-            @RequestBody AdminLoginDTO request,
-            HttpServletResponse response
+            @RequestBody AdminLoginDTO request
     ) {
         log.info("관리자 로그인 요청: {}", request.getUsername());
-        TokenDTO jwtResponse = adminService.adminLogin(request, response);
+        TokenDTO jwtResponse = adminService.adminLogin(request);
         SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()
                 .status(SuccessCode.ADMIN_LOGIN_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_LOGIN_SUCCESS.getMessage())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
@@ -9,8 +9,8 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface AdminService {
 
     //관리자 회원가입
-    TokenDTO adminJoin(AdminJoinDTO adminJoinDTO, HttpServletResponse response);
+    TokenDTO adminJoin(AdminJoinDTO adminJoinDTO);
 
     //관리자 로그인
-    TokenDTO adminLogin(AdminLoginDTO adminLoginDTO, HttpServletResponse response);
+    TokenDTO adminLogin(AdminLoginDTO adminLoginDTO);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
@@ -57,7 +57,7 @@ public class AdminServiceImpl implements AdminService {
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(username.getBytes()).toString() + "_" + role;
 
-        return authService.createAndPersistTokens(username, String.valueOf(UserRole.ADMIN), deviceId);
+        return authService.generateAndStoreTokensForAdmin(username, String.valueOf(UserRole.ADMIN), deviceId);
     }
 
     /**
@@ -83,7 +83,7 @@ public class AdminServiceImpl implements AdminService {
         String role = String.valueOf(UserRole.ADMIN);
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(username.getBytes()).toString() + "_" + role;
-        return authService.createAndPersistTokens(username, role, deviceId);
+        return authService.generateAndStoreTokensForAdmin(username, role, deviceId);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -31,8 +31,9 @@ public interface AuthService {
     // User 생성
     User createUser(String username, String nickname, String profileImageUrl, UserRole role);
 
-    // 토큰 생성
+    // 토큰 생성 및 저장
     TokenDTO generateAndStoreTokens(String username, String role, HttpServletResponse response);
+    TokenDTO createAndPersistTokens(String username, String role, String deviceId);
 
     // Refresh 토큰으로 Access토큰 발급
     TokenDTO reissueToken(String deviceId, String refresh);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -32,8 +32,8 @@ public interface AuthService {
     User createUser(String username, String nickname, String profileImageUrl, UserRole role);
 
     // 토큰 생성 및 저장
-    TokenDTO generateAndStoreTokens(String username, String role, HttpServletResponse response);
-    TokenDTO createAndPersistTokens(String username, String role, String deviceId);
+    TokenDTO generateAndStoreTokensForUser(String username, String role, HttpServletResponse response);
+    TokenDTO generateAndStoreTokensForAdmin(String username, String role, String deviceId);
 
     // Refresh 토큰으로 Access토큰 발급
     TokenDTO reissueToken(String deviceId, String refresh);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -99,8 +99,11 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public TokenDTO createAndPersistTokens(String username, String role, String deviceId) {
+    public TokenDTO generateAndStoreTokensForAdmin(String username, String role, String deviceId) {
         log.info("Access 토큰 및 Refresh 토큰 생성: 이메일 = {}, 역할 = {}, 기기 고유번호 = {}", username, role, deviceId);
+
+        // DB에서 username에 해당하는 기존 리프레시 토큰 삭제
+        refreshRepository.deleteByUsername(username);
 
         // 액세스 토큰 생성
         String accessToken = jwtUtil.createJwt("access", username, role, accessExpiration); // 60분
@@ -122,7 +125,7 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     @Transactional
-    public TokenDTO generateAndStoreTokens(String username, String role, HttpServletResponse response) {
+    public TokenDTO generateAndStoreTokensForUser(String username, String role, HttpServletResponse response) {
         log.info("Access 토큰 및 Refresh 토큰 생성: 이메일 = {}, 역할 = {}", username, role);
 
         // 액세스 토큰 생성
@@ -183,7 +186,7 @@ public class AuthServiceImpl implements AuthService {
         }
 
         log.info("구글 로그인 성공: 이메일 = {}", userInfo.getEmail());
-        return generateAndStoreTokens(userInfo.getEmail(), String.valueOf(UserRole.USER), response);
+        return generateAndStoreTokensForUser(userInfo.getEmail(), String.valueOf(UserRole.USER), response);
     }
 
     /**
@@ -227,7 +230,7 @@ public class AuthServiceImpl implements AuthService {
         socialLoginRepository.save(socialLogin);
 
         log.info("구글 회원가입 성공: 이메일 = {}", userInfo.getEmail());
-        return generateAndStoreTokens(userInfo.getEmail(), String.valueOf(UserRole.USER), response);
+        return generateAndStoreTokensForUser(userInfo.getEmail(), String.valueOf(UserRole.USER), response);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -49,7 +49,7 @@ public class TokenServiceImpl implements TokenService{
                 .build();
 
         refreshRepository.save(refreshEntity);
-        log.info("리프레시 토큰 저장 성공: 사용자 = {}, 토큰 = {}", username, refresh);
+        log.info("리프레시 토큰 저장 성공: 사용자 = {}, 토큰 = {}, 기기 고유번호 = {}", username, refresh, deviceId);
 
     }
 


### PR DESCRIPTION
- Refresh 엔티티에 기기 고유번호 추가: 일관된 고유 식별자(UUID)를 사용하여 관리
- 새로운 토큰 저장 전에 기존 Refresh 토큰을 사용자명으로 삭제하는 로직 추가: 기존 토큰 무효화로 보안 강화

Related to: TICO-162