### PR TITLE
[FEAT] 로그아웃 API 리프레시 토큰 처리 변경 (TICO-246)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -236,13 +236,27 @@ public class AuthController {
      * 로그아웃 API
      * 로그아웃하여 Refresh 토큰을 삭제합니다.
      *
-     * @param request  HTTP 요청 객체
-     * @param response HTTP 응답 객체
+     * @param deviceId 기기 고유 번호
+     * @param refreshToken 리프레시 토큰
      * @return 로그아웃 및 토큰 삭제 결과를 반환합니다.
      */
     @Operation(
-            summary = "로그아웃 및 토큰 만료",
-            description = "사용자가 로그아웃할 때, 쿠키의 Refresh 토큰을 만료시켜 삭제합니다."
+            summary = "로그아웃 및 토큰 삭제",
+            description = "사용자가 로그아웃할 때, 서버의 Refresh 토큰을 삭제합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Device-Id",
+                            description = "기기 고유 번호",
+                            in = ParameterIn.HEADER,
+                            required = true
+                    ),
+                    @Parameter(
+                            name = "Refresh-Token",
+                            description = "리프레시 토큰",
+                            in = ParameterIn.HEADER,
+                            required = true
+                    )
+            }
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그아웃 성공",
@@ -252,11 +266,11 @@ public class AuthController {
     })
     @DeleteMapping("/logout")
     public ResponseEntity<SuccessResponseDTO<String>> removeToken(
-            HttpServletRequest request,
-            HttpServletResponse response
+            @RequestHeader("Device-Id") String deviceId,
+            @RequestHeader("Refresh-Token") String refreshToken
     ) {
         // 액세스 토큰으로 현재 Redis 정보 삭제
-        tokenService.removeRefreshToken(request, response);
+        tokenService.removeRefreshToken(deviceId, refreshToken);
 
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -19,9 +19,6 @@ public interface AuthService {
     // 구글 ID 토큰 무결성 검사
     GoogleUserInfoDTO verifyGoogleIdToken(String idToken) throws GeneralSecurityException, IOException, IllegalArgumentException;
 
-    // 토큰 형태 검사
-    String extractToken(String header, TokenType tokenType);
-
     // 구글 로그인
     TokenDTO googleLogin(String idTokenHeader, HttpServletResponse response) throws GeneralSecurityException, IOException;
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -272,9 +272,7 @@ public class AuthServiceImpl implements AuthService {
         log.info("Refresh 토큰으로 Access 토큰 재발급 시도: deviceId = {}", deviceId);
 
         // 리프레시 토큰을 검증합니다.
-        log.info("Refresh 토큰 검증 시작: refreshToken = {}", refresh);
         tokenService.validateToken(refresh, "refresh");
-        log.info("Refresh 토큰 검증 완료");
 
         // DB에서 리프레시 토큰에 해당하는 리프레시 토큰 정보를 가져옵니다.
         Refresh refreshEntity = tokenService.getRefreshByRefreshToken(refresh);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -142,20 +142,35 @@ public class AuthServiceImpl implements AuthService {
      * 헤더에서 토큰 값을 추출
      *
      * @param header 토큰 헤더 (예: "Bearer <token>")
-     * @param tokenType 토큰의 타입 (Google ID 토큰 또는 JWT)
+     * @param tokenType 토큰의 타입 (Google ID 토큰, JWT ACCESS 토큰 또는 JWT REFRESH 토큰)
      * @return 추출된 토큰 값
      * @throws CustomException 토큰 헤더가 유효하지 않은 경우 예외 발생
      *                         - 헤더가 null이거나 비어있는 경우
      *                         - 헤더 형식이 "Bearer <token>" 형식이 아닌 경우
      *                         - 토큰 타입이 Google ID 토큰인데 헤더 형식이 맞지 않는 경우
+     *                         - JWT ACCESS 또는 REFRESH 토큰의 경우 헤더 형식이 맞지 않는 경우
      */
     @Override
     public String extractToken(String header, TokenType tokenType) {
 
         if (header == null || header.isEmpty() || !header.startsWith("Bearer ")) {
-            ErrorCode errorCode = tokenType.equals(TokenType.GOOGLE)
-                    ? ErrorCode.INVALID_GOOGLE_TOKEN_HEADER
-                    : ErrorCode.INVALID_AUTHORIZATION_HEADER;
+            ErrorCode errorCode;
+
+            switch (tokenType) {
+                case GOOGLE:
+                    errorCode = ErrorCode.INVALID_GOOGLE_TOKEN_HEADER;
+                    break;
+                case ACCESS:
+                    errorCode = ErrorCode.INVALID_AUTHORIZATION_HEADER;
+                    break;
+                case REFRESH:
+                    errorCode = ErrorCode.INVALID_REFRESH_TOKEN_HEADER;
+                    break;
+                default:
+                    errorCode = ErrorCode.INVALID_AUTHORIZATION_HEADER; // 기본값 설정
+                    break;
+            }
+
             throw new CustomException(errorCode);
         }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -139,45 +139,6 @@ public class AuthServiceImpl implements AuthService {
     }
 
     /**
-     * 헤더에서 토큰 값을 추출
-     *
-     * @param header 토큰 헤더 (예: "Bearer <token>")
-     * @param tokenType 토큰의 타입 (Google ID 토큰, JWT ACCESS 토큰 또는 JWT REFRESH 토큰)
-     * @return 추출된 토큰 값
-     * @throws CustomException 토큰 헤더가 유효하지 않은 경우 예외 발생
-     *                         - 헤더가 null이거나 비어있는 경우
-     *                         - 헤더 형식이 "Bearer <token>" 형식이 아닌 경우
-     *                         - 토큰 타입이 Google ID 토큰인데 헤더 형식이 맞지 않는 경우
-     *                         - JWT ACCESS 또는 REFRESH 토큰의 경우 헤더 형식이 맞지 않는 경우
-     */
-    @Override
-    public String extractToken(String header, TokenType tokenType) {
-
-        if (header == null || header.isEmpty() || !header.startsWith("Bearer ")) {
-            ErrorCode errorCode;
-
-            switch (tokenType) {
-                case GOOGLE:
-                    errorCode = ErrorCode.INVALID_GOOGLE_TOKEN_HEADER;
-                    break;
-                case ACCESS:
-                    errorCode = ErrorCode.INVALID_AUTHORIZATION_HEADER;
-                    break;
-                case REFRESH:
-                    errorCode = ErrorCode.INVALID_REFRESH_TOKEN_HEADER;
-                    break;
-                default:
-                    errorCode = ErrorCode.INVALID_AUTHORIZATION_HEADER; // 기본값 설정
-                    break;
-            }
-
-            throw new CustomException(errorCode);
-        }
-
-        return header.substring(7);
-    }
-
-    /**
      * 구글 ID 토큰으로 로그인 처리
      *
      * @param idTokenHeader Google-ID-Token 헤더에 포함된 구글 ID 토큰
@@ -192,7 +153,7 @@ public class AuthServiceImpl implements AuthService {
     public TokenDTO googleLogin(String idTokenHeader, HttpServletResponse response) throws GeneralSecurityException, IOException {
         log.info("구글 로그인 처리 시작");
 
-        String idToken = extractToken(idTokenHeader, TokenType.GOOGLE);
+        String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         GoogleUserInfoDTO userInfo = verifyGoogleIdToken(idToken);
 
         if (!userRepository.existsByUsername(userInfo.getEmail())) {
@@ -220,7 +181,7 @@ public class AuthServiceImpl implements AuthService {
     public TokenDTO googleJoin(String idTokenHeader, GoogleJoinDTO requestUserInfo, HttpServletResponse response) throws GeneralSecurityException, IOException {
         log.info("구글 회원가입 처리 시작");
 
-        String idToken = extractToken(idTokenHeader, TokenType.GOOGLE);
+        String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         GoogleUserInfoDTO userInfo = verifyGoogleIdToken(idToken);
 
         if (userRepository.existsByUsername(userInfo.getEmail())) {
@@ -278,16 +239,18 @@ public class AuthServiceImpl implements AuthService {
      * Refresh 토큰을 사용하여 Access 토큰 재발급
      *
      * @param deviceId 기기 고유 번호
-     * @param refresh 리프레시 토큰
+     * @param refreshHeader 리프레시 토큰
      * @return 새 Access 토큰을 포함하는 TokenDTO
      */
     @Transactional
     @Override
-    public TokenDTO reissueToken(String deviceId, String refresh) {
+    public TokenDTO reissueToken(String deviceId, String refreshHeader) {
         log.info("Refresh 토큰으로 Access 토큰 재발급 시도: deviceId = {}", deviceId);
+        // 헤더를 검증합니다.
+        String refresh = jwtUtil.extractToken(refreshHeader, TokenType.REFRESH);
 
         // 리프레시 토큰을 검증합니다.
-        tokenService.validateToken(refresh, "refresh");
+        jwtUtil.validateToken(refresh, "refresh");
 
         // DB에서 리프레시 토큰에 해당하는 리프레시 토큰 정보를 가져옵니다.
         Refresh refreshEntity = tokenService.getRefreshByRefreshToken(refresh);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -9,13 +9,16 @@ public interface TokenService {
     // 리프레쉬 토큰 저장
     void addRefreshEntity(String username, String refresh, Long expiredMs, String deviceId);
 
-    // 토큰 가져오기
+    // 토큰 엔티티 가져오기
     Refresh getRefreshByDeviceId(String deviceId);
     Refresh getRefreshByRefreshToken(String refreshToken);
+
+    // 기기 고유번호 검증
+//    void validateDeviceId(Refresh refreshEntity, String deviceId);
 
     // 토큰 검증
     void validateToken(String token, String expectedCategory);
 
     // 토큰 삭제
-    void removeRefreshToken(HttpServletRequest request, HttpServletResponse response);
+    void removeRefreshToken(String deviceId, String refreshToken);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -16,9 +16,6 @@ public interface TokenService {
     // 기기 고유번호 검증
 //    void validateDeviceId(Refresh refreshEntity, String deviceId);
 
-    // 토큰 검증
-    void validateToken(String token, String expectedCategory);
-
     // 토큰 삭제
     void removeRefreshToken(String deviceId, String refreshToken);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -4,14 +4,8 @@ import com.tico.pomoro_do.domain.user.entity.Refresh;
 import com.tico.pomoro_do.domain.user.repository.RefreshRepository;
 import com.tico.pomoro_do.global.auth.jwt.JWTUtil;
 import com.tico.pomoro_do.global.code.ErrorCode;
+import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.exception.CustomException;
-import com.tico.pomoro_do.global.util.CookieUtil;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -99,92 +93,30 @@ public class TokenServiceImpl implements TokenService{
                 });
     }
 
-    /**
-     * 주어진 토큰을 검증
-     *
-     * @param token 검증할 토큰
-     * @param expectedCategory 예상되는 토큰 카테고리 (예: "access" 또는 "refresh")
-     * @throws CustomException 검증 실패 시 발생하는 예외
-     */
-    @Override
-    public void validateToken(String token, String expectedCategory) {
-        log.info(expectedCategory + " 토큰 검증 시작: token = {}", token);
-
-        if (token == null) {
-            log.error("토큰이 null입니다. 카테고리 = {}", expectedCategory);
-            throw new CustomException(
-                    expectedCategory.equals("access")
-                            ? ErrorCode.MISSING_ACCESS_TOKEN
-                            : ErrorCode.MISSING_REFRESH_TOKEN
-            );
-        }
-
-        // 토큰 만료 및 서명 오류 확인
-        try {
-            jwtUtil.isExpired(token);
-        } catch (ExpiredJwtException e) {
-            log.error("토큰 만료됨: 카테고리 = {}", expectedCategory);
-            throw new CustomException(
-                    expectedCategory.equals("access")
-                            ? ErrorCode.ACCESS_TOKEN_EXPIRED
-                            : ErrorCode.REFRESH_TOKEN_EXPIRED
-            );
-        } catch (SignatureException e) {
-            log.error("유효하지 않은 JWT 서명: 카테고리 = {}", expectedCategory);
-            throw new CustomException(ErrorCode.INVALID_JWT_SIGNATURE);
-        } catch (MalformedJwtException e) {
-            log.error("유효하지 않은 JWT 형식: 카테고리 = {}", expectedCategory);
-            throw new CustomException(ErrorCode.INVALID_MALFORMED_JWT);
-        } catch (UnsupportedJwtException e) {
-            log.error("지원하지 않는 JWT: 카테고리 = {}", expectedCategory);
-            throw new CustomException(ErrorCode.UNSUPPORTED_JWT);
-        } catch (IllegalArgumentException e) {
-            log.error("잘못된 JWT 토큰: 카테고리 = {}", expectedCategory);
-            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT);
-        }
-
-        // 토큰 카테고리 확인
-        String category = jwtUtil.getCategory(token);
-        if (!category.equals(expectedCategory)) {
-            log.error("토큰 카테고리 불일치: 예상 = {}, 실제 = {}", expectedCategory, category);
-            throw new CustomException(
-                    expectedCategory.equals("access")
-                            ? ErrorCode.INVALID_ACCESS_TOKEN
-                            : ErrorCode.INVALID_REFRESH_TOKEN
-            );
-        }
-
-        log.info(expectedCategory + " 토큰 검증 완료");
-    }
-
-    //만료기간이 지난 토큰은 스케줄러를 돌려서 삭제하라.
+    // 만료기간이 지난 토큰은 스케줄러를 돌려서 삭제하라.
     /**
      * 로그아웃 시 리프레시 토큰 삭제
      *
      * @param deviceId 기기 고유 번호
-     * @param refreshToken 리프레시 토큰
+     * @param refreshHeader 리프레시 토큰
      */
-    @Transactional
     @Override
-    public void removeRefreshToken(String deviceId, String refreshToken) {
-        // 리프레시 토큰이 없는 경우, 로그를 기록하고 예외를 발생시킵니다.
-        if (refreshToken == null || refreshToken.isEmpty()) {
-            log.warn("리프레시 토큰을 입력해주세요.");
-            throw new CustomException(ErrorCode.MISSING_REFRESH_TOKEN);
-        }
-
+    @Transactional
+    public void removeRefreshToken(String deviceId, String refreshHeader) {
+        // 헤더를 검증합니다.
+        String refresh = jwtUtil.extractToken(refreshHeader, TokenType.REFRESH);
         // 리프레시 토큰을 검증합니다.
-        validateToken(refreshToken, "refresh");
+        jwtUtil.validateToken(refresh, "refresh");
 
         // DB에서 리프레시 토큰에 해당하는 리프레시 토큰 정보를 가져옵니다.
-        Refresh refreshEntity = getRefreshByRefreshToken(refreshToken);
+        Refresh refreshEntity = getRefreshByRefreshToken(refresh);
 
         // DB에 저장된 deviceId와 요청된 deviceId이 일치하는지 확인합니다.
         validateDeviceId(refreshEntity, deviceId);
 
         log.info("로그아웃: 리프레시 토큰 삭제 시작");
         // DB에서 리프레시 토큰을 제거합니다.
-        refreshRepository.deleteByRefreshToken(refreshToken);
+        refreshRepository.deleteByRefreshToken(refresh);
         log.info("로그아웃: 리프레시 토큰 삭제 완료");
     }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
@@ -105,8 +105,9 @@ public enum ErrorCode {
     MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "T-205", "액세스 토큰이 제공되지 않았습니다."),
     MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "T-206", "리프레시 토큰이 제공되지 않았습니다."),
     INVALID_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, "T-207", "Authorization 헤더의 토큰이 유효하지 않습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "T-208", "제공된 리프레시 토큰과 서버의 토큰이 일치하지 않습니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "T-209", "제공된 리프레시 토큰이 서버에 존재하지 않습니다."),
+    INVALID_REFRESH_TOKEN_HEADER(HttpStatus.BAD_REQUEST, "T-208", "Refresh-Token 헤더의 토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "T-209", "제공된 리프레시 토큰과 서버의 토큰이 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "T-210", "제공된 리프레시 토큰이 서버에 존재하지 않습니다."),
 
     // JWT 검증 관련 에러 - 230번대
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "T-231", "JWT 서명 검증에 실패했습니다."),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/enums/TokenType.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/enums/TokenType.java
@@ -4,5 +4,7 @@ public enum TokenType {
 
     GOOGLE,
 
-    JWT
+    ACCESS,
+
+    REFRESH
 }


### PR DESCRIPTION
- 쿠키 기반 리프레시 토큰 관리 삭제
- 헤더에서 리프레시 토큰과 기기 고유 번호 받음
- 검증 후 DB에서 리프레시 토큰 삭제
- JWT 토큰 유형에 따라 구체적인 오류 코드를 반환하도록 수정
- 토큰 검증 및 추출 로직을 `JWTUtil`에서 처리하도록 변경
- 순환 의존성 문제 해결 및 코드 중복 제거

Related to: TICO-162, TICO-206, TICO-246, TICO-241