### PR TITLE
[FEAT] 로그인 API에 디바이스 정보 추가 (TICO-240)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -50,10 +50,8 @@ public class AdminController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "409", description = "이미 등록된 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "409", description = "이미 등록된 사용자")
     })
     @PostMapping("/join")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminJoin(
@@ -88,12 +86,9 @@ public class AdminController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "404", description = "등록되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "등록되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없음")
     })
     @PostMapping("/login")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> adminLogin(

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -53,7 +53,6 @@ public class AuthController {
      *
      * @param googleIdToken Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
-     * @param response HttpServletResponse 객체
      * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
      * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
      */
@@ -78,7 +77,7 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "Google-ID-Token 헤더의 토큰이 유효하지 않음",
+            @ApiResponse(responseCode = "400", description = "Google-ID-Token 또는 Device-ID 헤더의 토큰이 유효하지 않음",
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
             @ApiResponse(responseCode = "401", description = "구글 ID 토큰이 유효하지 않음",
                     content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
@@ -88,12 +87,11 @@ public class AuthController {
     @PostMapping("/google/login")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleLogin(
             @RequestHeader("Google-ID-Token") String googleIdToken,
-            @RequestHeader("Device-ID") String deviceId,
-            HttpServletResponse response
+            @RequestHeader("Device-ID") String deviceId
     ) {
         try {
             // AuthService를 통해 구글 로그인을 처리하고 JWT 토큰을 발급받습니다.
-            TokenDTO jwtResponse = authService.googleLogin(googleIdToken, response);
+            TokenDTO jwtResponse = authService.googleLogin(googleIdToken, deviceId);
 
             // 성공 응답 생성
             SuccessResponseDTO<TokenDTO> successResponse = SuccessResponseDTO.<TokenDTO>builder()

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -53,13 +53,14 @@ public class AuthController {
      *
      * @param googleIdToken Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
-     * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
-     * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
+     * @return 성공 시 JWT 토큰 정보가 담긴 SuccessResponseDTO 반환
+     * @throws CustomException 구글 ID 토큰 검증 실패 시 CustomException 발생
      */
     @Operation(
             summary = "구글 로그인",
             description = "구글 소셜 로그인을 통해 사용자를 인증하고 JWT 토큰을 발급합니다. <br>"
-                    + "Google-ID-Token 헤더에 구글 ID 토큰을 입력해야 합니다. 예시: Bearer <id_token>",
+                    + "Google-ID-Token 헤더에 구글 ID 토큰을 입력해야 합니다. 예시: Bearer <id_token> <br>"
+                    + "Device-ID 헤더에 기기의 고유 번호를 입력해야 합니다.",
             parameters = {
                     @Parameter(
                             name = "Google-ID-Token",
@@ -77,12 +78,9 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "Google-ID-Token 또는 Device-ID 헤더의 토큰이 유효하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "401", description = "구글 ID 토큰이 유효하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "404", description = "등록되지 않은 사용자 (code: U-104)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "Google-ID-Token 헤더 또는 Device-ID 헤더의 값이 유효하지 않음"),
+            @ApiResponse(responseCode = "401", description = "구글 ID 토큰이 유효하지 않음"),
+            @ApiResponse(responseCode = "404", description = "등록되지 않은 사용자 (code: U-104)")
     })
     @PostMapping("/google/login")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleLogin(
@@ -112,7 +110,7 @@ public class AuthController {
      * @param googleIdTokenHeader Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param requestUserInfo 회원가입 요청 정보가 포함된 DTO
      * @param response HttpServletResponse 객체
-     * @return 성공 시 JwtDTO를 포함하는 SuccessResponseDTO
+     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
      * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
      */
     @Operation(
@@ -128,12 +126,9 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "401", description = "구글 ID 토큰이 유효하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "400", description = "Google-ID-Token 헤더의 토큰이 유효하지 않음 또는 요청 본문이 잘못됨",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "409", description = "이미 등록된 사용자 (code: U-105)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "401", description = "구글 ID 토큰이 유효하지 않음"),
+            @ApiResponse(responseCode = "400", description = "Google-ID-Token 헤더의 토큰이 유효하지 않음 또는 요청 본문이 잘못됨"),
+            @ApiResponse(responseCode = "409", description = "이미 등록된 사용자 (code: U-105)")
     })
     @PostMapping("/google/join")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleJoin(
@@ -158,9 +153,10 @@ public class AuthController {
     /**
      * 토큰 재발급 API
      *
-     * @param deviceId 기기 고유 번호
-     * @param refreshToken 리프레시 토큰
-     * @return 재발급된 토큰을 포함하는 SuccessResponseDTO
+     * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
+     * @param refreshToken Refresh-Token 헤더에 포함된 리프레시 토큰
+     * @return 재발급된 JWT 토큰 정보가 담긴 SuccessResponseDTO 반환
+     * @throws CustomException 리프레시 토큰 검증 실패 시 CustomException 발생
      */
     @Operation(
             summary = "토큰 재발급",
@@ -182,14 +178,9 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "401", description = "리프레시 토큰이 유효하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "404", description = "기기 ID 또는 리프레시 토큰이 DB에 존재하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "리프레시 토큰이 유효하지 않음"),
+            @ApiResponse(responseCode = "404", description = "기기 ID 또는 리프레시 토큰이 DB에 존재하지 않음"),
     })
     @PostMapping("/token/reissue")
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> reissueToken(
@@ -211,11 +202,13 @@ public class AuthController {
 
     /**
      * 로그아웃 API
-     * 로그아웃하여 Refresh 토큰을 삭제합니다.
      *
-     * @param deviceId 기기 고유 번호
-     * @param refreshToken 리프레시 토큰
-     * @return 로그아웃 및 토큰 삭제 결과를 반환합니다.
+     * 사용자가 로그아웃 시, 서버의 리프레시 토큰을 삭제합니다.
+     *
+     * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
+     * @param refreshToken Refresh-Token 헤더에 포함된 리프레시 토큰
+     * @return 로그아웃 성공 메시지를 담은 SuccessResponseDTO 반환
+     * @throws CustomException 리프레시 토큰 삭제 실패 시 CustomException 발생
      */
     @Operation(
             summary = "로그아웃 및 토큰 삭제",
@@ -237,8 +230,7 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "400", description = "로그아웃 요청이 잘못됨",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @DeleteMapping("/logout")
     public ResponseEntity<SuccessResponseDTO<String>> removeToken(
@@ -260,7 +252,14 @@ public class AuthController {
 
     /**
      * JWT 토큰 검증 API
+     *
+     * 전달된 JWT 토큰이 유효한지 검증합니다.
      * 이 엔드포인트는 JWT 인증이 필요하지 않습니다.
+     *
+     * @param request HTTP 요청 객체
+     * @param tokenType 검증할 토큰 타입 (ACCESS 또는 REFRESH)
+     * @return 토큰 검증 성공 메시지를 담은 SuccessResponseDTO 반환
+     * @throws CustomException 토큰 검증 실패 시 CustomException 발생
      */
     @Operation(
             summary = "JWT 토큰 검증",
@@ -269,10 +268,8 @@ public class AuthController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토큰 검증 성공"),
-            @ApiResponse(responseCode = "401", description = "토큰이 유효하지 않음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class))),
-            @ApiResponse(responseCode = "400", description = "토큰 헤더가 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponseEntity.class)))
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 토큰 헤더 없음"),
+            @ApiResponse(responseCode = "401", description = "토큰이 유효하지 않음")
     })
     @GetMapping("/token/validate")
     public ResponseEntity<SuccessResponseDTO<String>> validateToken(HttpServletRequest request, @RequestParam("tokenType") TokenType tokenType) {

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
@@ -57,7 +57,7 @@ public class AdminServiceImpl implements AdminService {
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(username.getBytes()).toString() + "_" + role;
 
-        return authService.generateAndStoreTokensForAdmin(username, String.valueOf(UserRole.ADMIN), deviceId);
+        return authService.generateAndStoreTokens(username, String.valueOf(UserRole.ADMIN), deviceId);
     }
 
     /**
@@ -83,7 +83,7 @@ public class AdminServiceImpl implements AdminService {
         String role = String.valueOf(UserRole.ADMIN);
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(username.getBytes()).toString() + "_" + role;
-        return authService.generateAndStoreTokensForAdmin(username, role, deviceId);
+        return authService.generateAndStoreTokens(username, role, deviceId);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -20,7 +20,7 @@ public interface AuthService {
     GoogleUserInfoDTO verifyGoogleIdToken(String idToken) throws GeneralSecurityException, IOException, IllegalArgumentException;
 
     // 구글 로그인
-    TokenDTO googleLogin(String idTokenHeader, HttpServletResponse response) throws GeneralSecurityException, IOException;
+    TokenDTO googleLogin(String idTokenHeader, String deviceId) throws GeneralSecurityException, IOException;
 
     // 구글 회원가입
     TokenDTO googleJoin(String idTokenHeader, GoogleJoinDTO request, HttpServletResponse response)  throws GeneralSecurityException, IOException;
@@ -30,7 +30,7 @@ public interface AuthService {
 
     // 토큰 생성 및 저장
     TokenDTO generateAndStoreTokensForUser(String username, String role, HttpServletResponse response);
-    TokenDTO generateAndStoreTokensForAdmin(String username, String role, String deviceId);
+    TokenDTO generateAndStoreTokens(String username, String role, String deviceId);
 
     // Refresh 토큰으로 Access토큰 발급
     TokenDTO reissueToken(String deviceId, String refresh);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -124,7 +124,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public TokenDTO generateAndStoreTokensForUser(String username, String role, HttpServletResponse response) {
-        log.info("Access 토큰 및 Refresh 토큰 생성: 이메일 = {}, 역할 = {}", username, role);
 
         // 액세스 토큰 생성
         String accessToken = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); // 60분
@@ -175,7 +174,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public TokenDTO googleJoin(String idTokenHeader, GoogleJoinDTO requestUserInfo, HttpServletResponse response) throws GeneralSecurityException, IOException {
-        log.info("구글 회원가입 처리 시작");
 
         String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         GoogleUserInfoDTO userInfo = verifyGoogleIdToken(idToken);
@@ -217,7 +215,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public User createUser(String username, String nickname, String profileImageUrl, UserRole role) {
-        log.info("새 사용자 생성: 이메일 = {}, 닉네임 = {}", username, nickname);
 
         User user = User.builder()
                 .username(username)
@@ -241,7 +238,6 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public TokenDTO reissueToken(String deviceId, String refreshHeader) {
-        log.info("Refresh 토큰으로 Access 토큰 재발급 시도: deviceId = {}", deviceId);
         // 헤더를 검증합니다.
         String refresh = jwtUtil.extractToken(refreshHeader, TokenType.REFRESH);
 
@@ -260,8 +256,6 @@ public class AuthServiceImpl implements AuthService {
         // 리프레시 토큰에서 사용자 정보를 추출합니다.
         String username = jwtUtil.getUsername(refresh);
         String role = jwtUtil.getRole(refresh);
-
-        log.info("새로운 Access, Refresh 토큰 생성");
 
         // 새로운 액세스 및 리프레시 토큰을 생성합니다.
         String newAccess = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); // 60분

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -104,9 +104,9 @@ public class AuthServiceImpl implements AuthService {
         refreshRepository.deleteByDeviceId(deviceId);
 
         // 액세스 토큰 생성
-        String accessToken = jwtUtil.createJwt("access", username, role, accessExpiration); // 60분
+        String accessToken = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); // 60분
         // 리프레시 토큰 생성
-        String refreshToken = jwtUtil.createJwt("refresh", username, role, refreshExpiration); // 24시간
+        String refreshToken = jwtUtil.createJwt(TokenType.REFRESH.name(), username, role, refreshExpiration); // 24시간
         // 리프레시 토큰을 DB에 저장
         tokenService.addRefreshEntity(username, refreshToken, refreshExpiration, deviceId);
 
@@ -127,9 +127,9 @@ public class AuthServiceImpl implements AuthService {
         log.info("Access 토큰 및 Refresh 토큰 생성: 이메일 = {}, 역할 = {}", username, role);
 
         // 액세스 토큰 생성
-        String accessToken = jwtUtil.createJwt("access", username, role, accessExpiration); // 60분
+        String accessToken = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); // 60분
         // 리프레시 토큰 생성
-        String refreshToken = jwtUtil.createJwt("refresh", username, role, refreshExpiration); // 24시간
+        String refreshToken = jwtUtil.createJwt(TokenType.REFRESH.name(), username, role, refreshExpiration); // 24시간
         // 리프레시 토큰을 DB에 저장
 //        tokenService.addRefreshEntity(username, refreshToken, refreshExpiration);
 
@@ -264,8 +264,8 @@ public class AuthServiceImpl implements AuthService {
         log.info("새로운 Access, Refresh 토큰 생성");
 
         // 새로운 액세스 및 리프레시 토큰을 생성합니다.
-        String newAccess = jwtUtil.createJwt("access", username, role, accessExpiration); // 60분
-        String newRefresh = jwtUtil.createJwt("refresh", username, role, refreshExpiration);
+        String newAccess = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); // 60분
+        String newRefresh = jwtUtil.createJwt(TokenType.REFRESH.name(), username, role, refreshExpiration);
 
         // DB에서 deviceId에 해당하는 기존 리프레시 토큰을 삭제하고,
         // 새로운 리프레시 토큰을 저장합니다.

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/ImageServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/ImageServiceImpl.java
@@ -129,7 +129,6 @@ public class ImageServiceImpl implements ImageService{
                     throw new CustomException(ErrorCode.S3_UPLOAD_FAILED);
             }
 
-
         } catch (SdkClientException e) {
             // AWS SDK 클라이언트 예외 처리
             log.error("S3 클라이언트에서 오류 발생: {}", e.getMessage());

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -24,11 +24,12 @@ public class TokenServiceImpl implements TokenService{
     private final RefreshRepository refreshRepository;
 
     /**
-     * 새로운 리프레시 토큰 저장
+     * 새로운 리프레시 토큰을 저장합니다.
      *
      * @param username 사용자 이메일
      * @param refresh 새로운 리프레시 토큰
      * @param expiredMs 토큰 만료 시간 (밀리초 단위)
+     * @param deviceId 기기 고유 번호
      */
     @Transactional
     @Override
@@ -52,7 +53,6 @@ public class TokenServiceImpl implements TokenService{
      * 주어진 deviceId로 리프레시 토큰 엔티티를 가져옵니다.
      *
      * @param deviceId 기기 고유 번호
-     * @return Refresh 엔티티
      * @throws CustomException 기기 ID가 DB에 존재하지 않을 때 발생하는 예외
      */
     @Override
@@ -82,7 +82,6 @@ public class TokenServiceImpl implements TokenService{
      * 주어진 리프레시 토큰으로 리프레시 토큰 엔티티를 가져옵니다.
      *
      * @param refreshToken 리프레시 토큰
-     * @return Refresh 엔티티
      * @throws CustomException 리프레시 토큰이 DB에 존재하지 않을 때 발생하는 예외
      */
     @Override
@@ -123,7 +122,6 @@ public class TokenServiceImpl implements TokenService{
      * 주어진 토큰 타입에 대한 SuccessCode를 반환
      *
      * @param tokenType 검증할 토큰 타입
-     * @return SuccessCode
      */
     @Override
     public SuccessCode getSuccessCodeForTokenType(TokenType tokenType) {

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -115,10 +115,8 @@ public class TokenServiceImpl implements TokenService{
         // DB에 저장된 deviceId와 요청된 deviceId이 일치하는지 확인합니다.
         validateDeviceId(refreshEntity, deviceId);
 
-        log.info("로그아웃: 리프레시 토큰 삭제 시작");
         // DB에서 리프레시 토큰을 제거합니다.
         refreshRepository.deleteByRefreshToken(refresh);
-        log.info("로그아웃: 리프레시 토큰 삭제 완료");
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
@@ -120,7 +120,6 @@ public class JWTUtil {
      * @throws CustomException 검증 실패 시 발생하는 예외
      */
     public void validateToken(String token, TokenType expectedCategory) {
-        log.info("토큰 검증 시작: 카테고리 = {}", expectedCategory);
 
         if (token == null) {
             log.error("토큰이 없습니다. 카테고리 = {}", expectedCategory);
@@ -155,23 +154,23 @@ public class JWTUtil {
         try {
             isExpired(token);
         } catch (ExpiredJwtException e) {
-            log.error("{} 토큰 만료됨: 카테고리 = {}, 이유 = {}", expectedCategory, expectedCategory, e.getMessage());
+            log.error("토큰 만료됨: 카테고리 = {}, 이유 = {}", expectedCategory, e.getMessage());
             throw new CustomException(
                     expectedCategory == TokenType.ACCESS
                             ? ErrorCode.ACCESS_TOKEN_EXPIRED
                             : ErrorCode.REFRESH_TOKEN_EXPIRED
             );
         } catch (SignatureException e) {
-            log.error("{} 유효하지 않은 JWT 서명: 카테고리 = {}, 이유 = {}", expectedCategory, expectedCategory, e.getMessage());
+            log.error("유효하지 않은 JWT 서명: 카테고리 = {}, 이유 = {}", expectedCategory, e.getMessage());
             throw new CustomException(ErrorCode.INVALID_JWT_SIGNATURE);
         } catch (MalformedJwtException e) {
-            log.error("{} 유효하지 않은 JWT 형식: 카테고리 = {}, 이유 = {}", expectedCategory, expectedCategory, e.getMessage());
+            log.error("유효하지 않은 JWT 형식: 카테고리 = {}, 이유 = {}", expectedCategory, e.getMessage());
             throw new CustomException(ErrorCode.INVALID_MALFORMED_JWT);
         } catch (UnsupportedJwtException e) {
-            log.error("{} 지원하지 않는 JWT: 카테고리 = {}, 이유 = {}", expectedCategory, expectedCategory, e.getMessage());
+            log.error("지원하지 않는 JWT: 카테고리 = {}, 이유 = {}", expectedCategory, e.getMessage());
             throw new CustomException(ErrorCode.UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
-            log.error("{} 잘못된 JWT 토큰: 카테고리 = {}, 이유 = {}", expectedCategory, expectedCategory, e.getMessage());
+            log.error("잘못된 JWT 토큰: 카테고리 = {}, 이유 = {}", expectedCategory, e.getMessage());
             throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT);
         }
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
@@ -86,7 +86,8 @@ public class JWTUtil {
      */
     public String extractToken(String header, TokenType tokenType) {
 
-        if (header == null || header.isEmpty() || !header.startsWith("Bearer ")) {
+        //  header가 "Bearer "로 시작하지 않는 경우 빈 문자열 ("")도 이 조건에 의해 걸러지므로 header.isEmpty() 불필요하다.
+        if (header == null || !header.startsWith("Bearer ")) {
             ErrorCode errorCode;
 
             switch (tokenType) {
@@ -135,7 +136,7 @@ public class JWTUtil {
 
         // 토큰 카테고리 확인
         String category = getCategory(token);
-        if (!category.equals(expectedCategory.name().toLowerCase())) {
+        if (!category.equals(expectedCategory.name())) {
             log.error("토큰 카테고리 불일치: 예상 = {}, 실제 = {}", expectedCategory, category);
             throw new CustomException(ErrorCode.INVALID_TOKEN_TYPE);
         }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
@@ -46,8 +46,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String username = obtainUsername(request);
         String password = obtainPassword(request);
 
-        log.info("LoginFilter에서 username 획득 여부 확인 - username: " + username);
-
         //인증 진행
         //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token(바구니)에 담아야 함
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.tico.pomoro_do.global.auth.jwt;
 
 import com.tico.pomoro_do.domain.user.service.TokenService;
+import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,18 +72,18 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = auth.getAuthority();
 
         //토큰 생성 (카테고리, 유저이름, 역할, 만료시간)
-        String access = jwtUtil.createJwt("access", username, role, accessExpiration); //60분
-        String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiration); //24시간
+        String access = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); //60분
+        String refresh = jwtUtil.createJwt(TokenType.REFRESH.name(), username, role, refreshExpiration); //24시간
 
         //Refresh 토큰 저장
-        String deviceId = request.getHeader("Device-Id");
+        String deviceId = request.getHeader("Device-ID");
         tokenService.addRefreshEntity(username, refresh, refreshExpiration, deviceId);
 
         //응답 설정
         //access 토큰 헤더에 넣어서 응답 (key: value 형태) -> 예시) access: 인증토큰(string)
-        response.setHeader("access", access);
+        response.setHeader(TokenType.ACCESS.name(), access);
         //refresh 토큰 쿠키에 넣어서 응답
-        response.addCookie(CookieUtil.createCookie("refresh", refresh));
+        response.addCookie(CookieUtil.createCookie(TokenType.REFRESH.name(), refresh));
         response.setStatus(HttpStatus.OK.value());
     }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/CookieUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/CookieUtil.java
@@ -16,10 +16,8 @@ public class CookieUtil {
 
     @Value("${jwt.refresh-expiration}")
     private static int refreshExpiration; // (24*60*60 = 24시간)
-
     // 쿠키에서 가져온다.
     public static String getRefreshToken(HttpServletRequest request) {
-        log.info("쿠키에서 refresh 토큰 찾기");
 
         //get refresh token
         String refresh = null;
@@ -32,7 +30,7 @@ public class CookieUtil {
                 }
             }
         }
-        log.info("쿠키의 refresh 토큰: " + refresh);
+
         return refresh;
     }
 
@@ -40,8 +38,6 @@ public class CookieUtil {
     //쿠키 만들기
 //    public static Cookie createCookie(String key, String value, int expireLength) {
     public static Cookie createCookie(String key, String value) {
-        log.info(key + " 쿠키 생성");
-
         //value: jwt
         Cookie cookie = new Cookie(key, value);
         //쿠키의 생명주기 - 살아있을 시간 (24*60*60 = 24시간)
@@ -58,7 +54,6 @@ public class CookieUtil {
 
     // 쿠키의 이름을 입력받아 쿠키 삭제
     public static void expireCookie(HttpServletResponse response, String cookieName) {
-        log.info(cookieName + " 쿠키 삭제 (만료)");
         // 실제로 삭제하는 방법은 없으므로 쿠키 value를 빈 값으로 바꾸고
         // 만료 시간을 0으로 설정해 쿠키가 재생성 되자마자 만료 처리한다.
         // 브라우저는 이전 쿠키를 무시하고 새로운 쿠키를 사용한다.

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/CookieUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/CookieUtil.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.global.util;
 
+import com.tico.pomoro_do.global.enums.TokenType;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,7 +26,7 @@ public class CookieUtil {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if (cookie.getName().equals("refresh")) {
+                if (cookie.getName().equals(TokenType.REFRESH.name())) {
                     refresh = cookie.getValue();
                     break;
                 }


### PR DESCRIPTION
- 클라이언트에서 디바이스 정보를 전달하기 위해 Device-ID 헤더 추가
- 리프레시 토큰 검증 강화를 위해 기기 고유번호를 리프레시 토큰과 함께 DB에 저장
- 액세스 및 리프레시 토큰 문자열을 이넘으로 관리하여 가독성 향상
- 불필요한 로그 메시지 및 Swagger 로직 삭제, 주석 수정

Related to: TICO-162, TICO-164, TICO-206