### PR TITLE
[FEAT] 회원가입 API 개선 (TICO-236)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -6,7 +6,6 @@ import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
 import com.tico.pomoro_do.domain.user.service.AdminService;
 import com.tico.pomoro_do.global.code.SuccessCode;
 import com.tico.pomoro_do.global.response.SuccessResponseDTO;
-import com.tico.pomoro_do.global.exception.ErrorResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,7 +16,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Admin: 관리자", description = "백엔드를 테스트를 위한 API")
 @RestController

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -19,6 +19,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -139,7 +140,7 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "헤더의 토큰이 유효하지 않음 또는 요청 본문이 잘못됨"),
             @ApiResponse(responseCode = "409", description = "이미 등록된 사용자 (code: U-105)")
     })
-    @PostMapping("/google/join")
+    @PostMapping(value = "/google/join", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponseDTO<TokenDTO>> googleJoin(
             @RequestHeader("Google-ID-Token") String googleIdTokenHeader,
             @RequestHeader("Device-ID") String deviceId,

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
@@ -3,10 +3,12 @@ package com.tico.pomoro_do.domain.user.controller;
 import com.tico.pomoro_do.domain.user.dto.response.ImageDTO;
 import com.tico.pomoro_do.domain.user.service.ImageService;
 import com.tico.pomoro_do.global.code.SuccessCode;
+import com.tico.pomoro_do.global.enums.S3Folder;
 import com.tico.pomoro_do.global.response.SuccessResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,13 +29,15 @@ public class ImageController {
     /**
      * 이미지 업로드 엔드포인트
      *
-     * @param file MultipartRequest로 받은 파일 업로드 요청
+     * @param image MultipartRequest로 받은 파일 업로드 요청
      * @return ResponseEntity 성공 응답 DTO를 포함한 ResponseEntity 객체
      */
-    @PostMapping("/upload")
-    public ResponseEntity<SuccessResponseDTO<ImageDTO>> imageUpload(@RequestParam("file") MultipartFile file) {
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponseDTO<ImageDTO>> imageUpload(
+            @RequestParam("image") MultipartFile image
+    ) {
 
-        String imageUrl = imageService.imageUpload(file, "images");
+        String imageUrl = imageService.imageUpload(image, S3Folder.IMAGES.getFolderName());
 
         ImageDTO imageDTO = ImageDTO.builder()
                 .url(imageUrl)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
@@ -33,7 +33,7 @@ public class ImageController {
     @PostMapping("/upload")
     public ResponseEntity<SuccessResponseDTO<ImageDTO>> imageUpload(@RequestParam("file") MultipartFile file) {
 
-        String imageUrl = imageService.imageUpload(file);
+        String imageUrl = imageService.imageUpload(file, "images");
 
         ImageDTO imageDTO = ImageDTO.builder()
                 .url(imageUrl)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/ImageDTO.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/ImageDTO.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Schema(description = "Image Response")
 public class ImageDTO {
 
-    @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/bucketname/uuid.jpg")
+    @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/foldername/bucketname/uuid.jpg")
     private final String url;
 
     @Builder

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthService.java
@@ -2,14 +2,10 @@ package com.tico.pomoro_do.domain.user.service;
 
 
 import com.tico.pomoro_do.domain.user.dto.GoogleUserInfoDTO;
-import com.tico.pomoro_do.domain.user.dto.request.GoogleJoinDTO;
-import com.tico.pomoro_do.domain.user.dto.response.JwtDTO;
 import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
 import com.tico.pomoro_do.domain.user.entity.User;
-import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.enums.UserRole;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -23,13 +19,12 @@ public interface AuthService {
     TokenDTO googleLogin(String idTokenHeader, String deviceId) throws GeneralSecurityException, IOException;
 
     // 구글 회원가입
-    TokenDTO googleJoin(String idTokenHeader, GoogleJoinDTO request, HttpServletResponse response)  throws GeneralSecurityException, IOException;
+    TokenDTO googleJoin(String idTokenHeader, String deviceId, String nickname, MultipartFile profileImage)  throws GeneralSecurityException, IOException;
 
     // User 생성
     User createUser(String username, String nickname, String profileImageUrl, UserRole role);
 
     // 토큰 생성 및 저장
-    TokenDTO generateAndStoreTokensForUser(String username, String role, HttpServletResponse response);
     TokenDTO generateAndStoreTokens(String username, String role, String deviceId);
 
     // Refresh 토큰으로 Access토큰 발급

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/ImageService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/ImageService.java
@@ -5,5 +5,5 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageService {
 
-    String imageUpload(MultipartFile file);
+    String imageUpload(MultipartFile file, String dirName);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTFilter.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.tico.pomoro_do.domain.user.dto.UserDTO;
 import com.tico.pomoro_do.global.auth.CustomUserDetails;
 import com.tico.pomoro_do.global.code.ErrorCode;
+import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.exception.ErrorResponseEntity;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
@@ -119,7 +120,7 @@ public class JWTFilter extends OncePerRequestFilter {
         //토큰이 access인지 확인 (발급시 페이로드에 명시)
         String category = jwtUtil.getCategory(accessToken);
 
-        if (!category.equals("access")) {
+        if (!category.equals(TokenType.ACCESS.name())) {
             //access 토큰이 아니면 응답 메시지와 상태코드 반환
             log.info("유효하지 않은 Access 토큰입니다. Access 토큰이 아닙니다.");
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/enums/S3Folder.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/enums/S3Folder.java
@@ -1,0 +1,16 @@
+package com.tico.pomoro_do.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum S3Folder {
+    IMAGES("images"),
+    PROFILES("profiles"),
+    DOCUMENTS("documents");
+
+    private final String folderName;
+
+    S3Folder(String folderName) {
+        this.folderName = folderName;
+    }
+}


### PR DESCRIPTION
- 파일을 S3에 폴더별로 저장하도록 변경하여 저장 방식 개선
- 기기 고유번호 및 리프레시 토큰 저장 기능을 추가하여 사용자 식별 강화
- 프로필 이미지 등록 및 S3 업로드 기능을 추가하여 이미지 관리 개선
- 토큰 카테고리를 문자열 대신 이넘으로 관리하여 코드의 가독성 향상

Related to: TICO-237, TICO-206, TICO-162, TICO-164