### PR TITLE
[FEAT] 회원 탈퇴 API 구현 (TICO-250)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.tico.pomoro_do.domain.user.controller;
 import com.tico.pomoro_do.domain.user.dto.response.TokenDTO;
 import com.tico.pomoro_do.domain.user.service.AuthService;
 import com.tico.pomoro_do.domain.user.service.TokenService;
+import com.tico.pomoro_do.global.auth.CustomUserDetails;
 import com.tico.pomoro_do.global.auth.jwt.JWTUtil;
 import com.tico.pomoro_do.global.code.ErrorCode;
 import com.tico.pomoro_do.global.code.SuccessCode;
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -256,11 +258,12 @@ public class AuthController {
     })
     @DeleteMapping("/logout")
     public ResponseEntity<SuccessResponseDTO<String>> removeToken(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestHeader("Device-ID") String deviceId,
-            @RequestHeader("Refresh-Token") String refreshToken
+            @RequestHeader("Refresh-Token") String refreshHeader
     ) {
         // 액세스 토큰으로 현재 Redis 정보 삭제
-        tokenService.removeRefreshToken(deviceId, refreshToken);
+        tokenService.removeRefreshToken(customUserDetails.getUsername(), deviceId, refreshHeader);
 
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AuthController.java
@@ -230,7 +230,7 @@ public class AuthController {
      * 사용자가 로그아웃 시, 서버의 리프레시 토큰을 삭제합니다.
      *
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
-     * @param refreshToken Refresh-Token 헤더에 포함된 리프레시 토큰
+     * @param refreshHeader Refresh-Token 헤더에 포함된 리프레시 토큰
      * @return 로그아웃 성공 메시지를 담은 SuccessResponseDTO 반환
      * @throws CustomException 리프레시 토큰 삭제 실패 시 CustomException 발생
      */
@@ -263,7 +263,7 @@ public class AuthController {
             @RequestHeader("Refresh-Token") String refreshHeader
     ) {
         // 액세스 토큰으로 현재 Redis 정보 삭제
-        tokenService.removeRefreshToken(customUserDetails.getUsername(), deviceId, refreshHeader);
+        tokenService.deleteRefreshTokenByDeviceId(customUserDetails.getUsername(), deviceId, refreshHeader);
 
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -11,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User: 사용자", description = "사용자 관련 API")
 @RestController
@@ -31,7 +28,7 @@ public class UserController {
      * @param customUserDetails 인증된 사용자 정보
      * @return 성공 시 사용자 상세 정보가 담긴 SuccessResponseDTO 반환
      */
-    @Operation(summary = "내 사용자 정보 조회", description = "인증된 사용자의 상세 정보를 조회합니다.")
+    @Operation(summary = "현재 사용자 정보 조회", description = "인증된 사용자의 상세 정보를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<SuccessResponseDTO<UserDetailDTO>> getMyDetail(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
@@ -62,6 +59,31 @@ public class UserController {
                 .data(userDetailResponse)
                 .build();
 
+        return ResponseEntity.ok(successResponse);
+    }
+
+    /**
+     * 현재 인증된 사용자의 계정을 삭제합니다.
+     *
+     * @param customUserDetails 현재 인증된 사용자 정보를 담고 있는 CustomUserDetails 객체
+     * @param deviceId 사용자 디바이스의 고유 식별자
+     * @param refreshToken 현재 사용자 디바이스의 리프레시 토큰
+     * @return 삭제 성공 시 SuccessResponseDTO를 포함하는 ResponseEntity 반환
+     */
+    @Operation(summary = "현재 사용자 계정 삭제", description = "현재 인증된 사용자의 계정을 삭제합니다.")
+    @DeleteMapping("/me")
+    public ResponseEntity<SuccessResponseDTO<String>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestHeader("Device-ID") String deviceId,
+            @RequestHeader("Refresh-Token") String refreshToken
+    ) {
+        userService.deleteUser(customUserDetails.getUsername(), deviceId, refreshToken);
+
+        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+                .status(SuccessCode.USER_DELETION_SUCCESS.getHttpStatus().value())
+                .message(SuccessCode.USER_DELETION_SUCCESS.getMessage())
+                .data(SuccessCode.USER_DELETION_SUCCESS.name())
+                .build();
         return ResponseEntity.ok(successResponse);
     }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
@@ -13,14 +13,11 @@ public interface RefreshRepository extends JpaRepository<Refresh, Long> {
     Optional<Refresh> findByRefreshToken(String refreshToken);
 
     // 해당 리프레쉬 토큰을 삭제하는 메소드
-    @Transactional
     void deleteByRefreshToken(String refreshToken);
 
     // 사용자 이름을 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
-    @Transactional
     void deleteByUsername(String username);
 
     // 디바이스 id를 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
-    @Transactional
     void deleteByDeviceId(String deviceId);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/RefreshRepository.java
@@ -9,11 +9,8 @@ import java.util.Optional;
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
 
     // 해당 리프레쉬 토큰의 존재 여부를 판단하는 메소드
-    boolean existsByRefreshToken(String refreshToken);
     Optional<Refresh> findByDeviceId(String deviceId);
-
     Optional<Refresh> findByRefreshToken(String refreshToken);
-
 
     // 해당 리프레쉬 토큰을 삭제하는 메소드
     @Transactional

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUsername(String username);
 
+    void deleteByUsername(String username);
+
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import com.tico.pomoro_do.global.auth.jwt.JWTUtil;
 import com.tico.pomoro_do.global.code.ErrorCode;
 import com.tico.pomoro_do.global.enums.*;
 import com.tico.pomoro_do.global.exception.CustomException;
+import com.tico.pomoro_do.global.util.ValidationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -120,7 +121,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenDTO googleLogin(String idTokenHeader, String deviceId) throws GeneralSecurityException, IOException {
         // deviceId 유효성 검사
-        validateDeviceId(deviceId);
+        ValidationUtils.validateDeviceId(deviceId);
         // 토큰 추출
         String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         // 구글 토큰 유효성 검증
@@ -170,43 +171,14 @@ public class AuthServiceImpl implements AuthService {
     }
 
     /**
-     * 디바이스 ID 검증 메서드
-     *
-     * @param deviceId 기기 고유 번호
-     */
-    private void validateDeviceId(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            log.error("유효하지 않은 입력: deviceId={}", deviceId);
-            throw new CustomException(ErrorCode.DEVICE_ID_EMPTY);
-        }
-    }
-
-    /**
-     * 닉네임 검증 메서드
-     *
-     * @param nickname 닉네임
-     */
-    private void validateNickname(String nickname) {
-        if (nickname == null || nickname.isEmpty()) {
-            log.error("유효하지 않은 입력: nickname={}", nickname);
-            throw new CustomException(ErrorCode.NICKNAME_EMPTY);
-        }
-
-        if (nickname.length() > 10) {
-            log.error("닉네임이 너무 깁니다: nickname={}", nickname);
-            throw new CustomException(ErrorCode.NICKNAME_TOO_LONG);
-        }
-    }
-
-    /**
      * 회원가입 입력값 검증 메서드
      *
      * @param deviceId 기기 고유 번호
      * @param nickname 닉네임
      */
     private void joinValidateInputs(String deviceId, String nickname) {
-        validateDeviceId(deviceId);
-        validateNickname(nickname);
+        ValidationUtils.validateDeviceId(deviceId);
+        ValidationUtils.validateNickname(nickname);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -13,11 +13,8 @@ public interface TokenService {
     Refresh getRefreshByDeviceId(String deviceId);
     Refresh getRefreshByRefreshToken(String refreshToken);
 
-    // 기기 고유번호 검증
-//    void validateDeviceId(Refresh refreshEntity, String deviceId);
-
     // 토큰 삭제
-    void removeRefreshToken(String deviceId, String refreshToken);
+    void removeRefreshToken(String username, String deviceId, String refreshToken);
 
     // 주어진 토큰 타입에 대한 토큰 검증 SuccessCode를 반환
     SuccessCode getSuccessCodeForTokenType(TokenType tokenType);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenService.java
@@ -14,7 +14,8 @@ public interface TokenService {
     Refresh getRefreshByRefreshToken(String refreshToken);
 
     // 토큰 삭제
-    void removeRefreshToken(String username, String deviceId, String refreshToken);
+    void deleteRefreshTokenByDeviceId(String username, String deviceId, String refreshHeader);
+    void deleteAllRefreshTokensByUsername(String username, String deviceId, String refreshHeader);
 
     // 주어진 토큰 타입에 대한 토큰 검증 SuccessCode를 반환
     SuccessCode getSuccessCodeForTokenType(TokenType tokenType);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -7,6 +7,7 @@ import com.tico.pomoro_do.global.code.ErrorCode;
 import com.tico.pomoro_do.global.code.SuccessCode;
 import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.exception.CustomException;
+import com.tico.pomoro_do.global.util.ValidationUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -71,10 +72,24 @@ public class TokenServiceImpl implements TokenService{
      * @param deviceId 기기 고유 번호
      * @throws CustomException deviceId 불일치 시 발생하는 예외
      */
-    private void validateDeviceId(Refresh refreshEntity, String deviceId) {
+    private void checkDeviceIdMatch(Refresh refreshEntity, String deviceId) {
         if (!refreshEntity.getDeviceId().equals(deviceId)) {
-            log.error("Device ID가 DB에 존재하지 않음: deviceId = {}", deviceId);
+            log.error("Device ID가 일치하지 않음: deviceId = {}", deviceId);
             throw new CustomException(ErrorCode.DEVICE_ID_MISMATCH);
+        }
+    }
+
+    /**
+     * 주어진 리프레시 엔티티와 username을 검증합니다.
+     *
+     * @param refreshEntity 리프레시 엔티티
+     * @param username 유저 이메일
+     * @throws CustomException username 불일치 시 발생하는 예외
+     */
+    private void checkUsernameMatch(Refresh refreshEntity, String username) {
+        if (!refreshEntity.getUsername().equals(username)) {
+            log.error("Username이 일치하지 않음: username = {}", username);
+            throw new CustomException(ErrorCode.USERNAME_MISMATCH);
         }
     }
 
@@ -97,14 +112,31 @@ public class TokenServiceImpl implements TokenService{
     /**
      * 로그아웃 시 리프레시 토큰 삭제
      *
+     * @param username 사용자 이름
      * @param deviceId 기기 고유 번호
      * @param refreshHeader 리프레시 토큰
      */
     @Override
     @Transactional
-    public void removeRefreshToken(String deviceId, String refreshHeader) {
+    public void removeRefreshToken(String username, String deviceId, String refreshHeader) {
+        validateRefreshTokenDetails(username, deviceId, refreshHeader);
+        // DB에서 deviceId에 해당하는 엔티티를 제거합니다.
+        refreshRepository.deleteByDeviceId(deviceId);
+    }
+
+    /**
+     * 리프레시 토큰을 검증하고, 유효성을 확인합니다.
+     *
+     * @param refreshHeader 리프레시 토큰 헤더
+     * @param deviceId 기기 고유 번호
+     * @param username 사용자 이름
+     */
+    private void validateRefreshTokenDetails(String username, String deviceId, String refreshHeader) {
+        // deviceId 유효성 검증
+        ValidationUtils.validateDeviceId(deviceId);
         // 헤더를 검증합니다.
         String refresh = jwtUtil.extractToken(refreshHeader, TokenType.REFRESH);
+
         // 리프레시 토큰을 검증합니다.
         jwtUtil.validateToken(refresh, TokenType.REFRESH);
 
@@ -112,10 +144,9 @@ public class TokenServiceImpl implements TokenService{
         Refresh refreshEntity = getRefreshByRefreshToken(refresh);
 
         // DB에 저장된 deviceId와 요청된 deviceId이 일치하는지 확인합니다.
-        validateDeviceId(refreshEntity, deviceId);
-
-        // DB에서 리프레시 토큰을 제거합니다.
-        refreshRepository.deleteByRefreshToken(refresh);
+        checkDeviceIdMatch(refreshEntity, deviceId);
+        // DB에 저장된 username과 요청된 username이 일치하는지 확인합니다.
+        checkUsernameMatch(refreshEntity, username);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/TokenServiceImpl.java
@@ -110,7 +110,7 @@ public class TokenServiceImpl implements TokenService{
 
     // 만료기간이 지난 토큰은 스케줄러를 돌려서 삭제하라.
     /**
-     * 로그아웃 시 리프레시 토큰 삭제
+     * 로그아웃 시 특정 기기에서의 리프레시 토큰 삭제
      *
      * @param username 사용자 이름
      * @param deviceId 기기 고유 번호
@@ -118,10 +118,24 @@ public class TokenServiceImpl implements TokenService{
      */
     @Override
     @Transactional
-    public void removeRefreshToken(String username, String deviceId, String refreshHeader) {
+    public void deleteRefreshTokenByDeviceId(String username, String deviceId, String refreshHeader) {
         validateRefreshTokenDetails(username, deviceId, refreshHeader);
         // DB에서 deviceId에 해당하는 엔티티를 제거합니다.
         refreshRepository.deleteByDeviceId(deviceId);
+    }
+
+    /**
+     * 회원탈퇴 시 회원의 모든 리프레시 토큰 삭제
+     *
+     * @param username 사용자 이름
+     * @param deviceId 기기 고유 번호
+     * @param refreshHeader 리프레시 토큰
+     */
+    @Override
+    public void deleteAllRefreshTokensByUsername(String username, String deviceId, String refreshHeader) {
+        validateRefreshTokenDetails(username, deviceId, refreshHeader);
+        // DB에서 username에 해당하는 모든 엔티티를 제거합니다.
+        refreshRepository.deleteByUsername(username);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
@@ -4,7 +4,12 @@ import com.tico.pomoro_do.domain.user.dto.response.UserDetailDTO;
 
 public interface UserService {
 
+    // 내 정보 조회
     UserDetailDTO getMyDetail(String username);
 
+    // 유저 조회
     UserDetailDTO getUserDetail(Long userId);
+
+    // 유저 삭제
+    void deleteUser(String username, String deviceId, String refreshHeader);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
@@ -10,8 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -19,6 +17,7 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService{
 
     final private UserRepository userRepository;
+    final private TokenService tokenService;
 
     @Override
     public UserDetailDTO getMyDetail(String username) {
@@ -41,6 +40,16 @@ public class UserServiceImpl implements UserService{
                 .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public void deleteUser(String username, String deviceId, String refreshHeader) {
+        // 해당 회원의 모든 리프레시 토큰 삭제
+        tokenService.deleteAllRefreshTokensByUsername(username,deviceId,refreshHeader);
+        // 해당 유저 삭제
+        userRepository.deleteByUsername(username);
+    }
+
 
     public User findByUsername(String username) {
         return userRepository.findByUsername(username)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
@@ -140,7 +140,7 @@ public class JWTUtil {
             throw new CustomException(ErrorCode.INVALID_TOKEN_TYPE);
         }
 
-        log.info("{} 토큰 검증 완료: token = {}", expectedCategory, token);
+        log.info("{} 토큰 검증 완료", expectedCategory);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
@@ -96,11 +96,13 @@ public enum ErrorCode {
 
     //유저 관련 에러: -100번대
     EMAIL_EXIST(HttpStatus.BAD_REQUEST, "U-100", "이미 사용 중인 이메일입니다."),
-    NICKNAME_EMPTY(HttpStatus.BAD_REQUEST, "U-101", "닉네임이 비어있거나 유효하지 않습니다."),
+    NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "U-101", "닉네임이 비어있거나 유효하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-102", "가입된 사용자가 아닙니다."),
     PROFILE_UPLOAD_FAILED(HttpStatus.FORBIDDEN, "U-103", "프로필 이미지 변경에 실패했습니다."),
     USER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "U-104", "이미 등록된 사용자입니다."),
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "U-105", "닉네임이 너무 깁니다. 최대 길이는 10자입니다."),
+    USERNAME_MISMATCH(HttpStatus.BAD_REQUEST, "U-106", "현재 유저의 정보와 일치하지 않습니다."),
+
 
     //Token 관련 에러 -200번대
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "T-201", "액세스 토큰이 만료되었습니다."),
@@ -129,7 +131,7 @@ public enum ErrorCode {
     DEVICE_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "D-300", "제공된 Device ID가 서버에 존재하지 않습니다."),
     INVALID_DEVICE_ID_HEADER(HttpStatus.BAD_REQUEST, "D-301", "Device ID 헤더의 값이 유효하지 않습니다."),
     DEVICE_ID_MISMATCH(HttpStatus.BAD_REQUEST, "D-302", "제공된 Device ID와 서버의 Device ID가 일치하지 않습니다."),
-    DEVICE_ID_EMPTY(HttpStatus.BAD_REQUEST, "D-303", "DEVICE ID가 비어있거나 유효하지 않습니다"),
+    DEVICE_ID_INVALID(HttpStatus.BAD_REQUEST, "D-303", "DEVICE ID가 비어있거나 유효하지 않습니다"),
 
     // 관리자 관련 에러: -400번대
     NOT_AN_ADMIN(HttpStatus.FORBIDDEN, "A-400", "관리자 권한이 없습니다."),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/SuccessCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode {
     GOOGLE_SIGNUP_SUCCESS(HttpStatus.CREATED, "구글 회원가입에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 및 토큰 삭제에 성공했습니다."),
     USER_FETCH_SUCCESS(HttpStatus.OK, "회원 조회에 성공했습니다."),
+    USER_DELETION_SUCCESS(HttpStatus.OK, "회원 탈퇴가 성공적으로 처리되었습니다."),
 
     //토큰
     ACCESS_TOKEN_REISSUED(HttpStatus.OK,  "액세스 토큰이 성공적으로 재발급되었습니다."),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/ValidationUtils.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/util/ValidationUtils.java
@@ -1,0 +1,37 @@
+package com.tico.pomoro_do.global.util;
+
+import com.tico.pomoro_do.global.code.ErrorCode;
+import com.tico.pomoro_do.global.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ValidationUtils {
+
+    /**
+     * 디바이스 ID 검증 메서드
+     *
+     * @param deviceId 기기 고유 번호
+     */
+    public static void validateDeviceId(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            log.error("유효하지 않은 입력: deviceId={}", deviceId);
+            throw new CustomException(ErrorCode.DEVICE_ID_INVALID);
+        }
+    }
+
+    /**
+     * 닉네임 검증 메서드
+     *
+     * @param nickname 닉네임
+     */
+    public static void validateNickname(String nickname) {
+        if (nickname == null || nickname.isEmpty()) {
+            log.error("유효하지 않은 입력: nickname={}", nickname);
+            throw new CustomException(ErrorCode.NICKNAME_INVALID);
+        }
+        if (nickname.length() > 10) {
+            log.error("닉네임이 너무 깁니다: nickname={}", nickname);
+            throw new CustomException(ErrorCode.NICKNAME_TOO_LONG);
+        }
+    }
+}


### PR DESCRIPTION
- 유효성 검사 로직을 ValidationUtils 클래스로 분리
- 로그아웃 기능에 USERNAME 검증 로직 추가
- 현재 인증된 사용자의 계정을 삭제하는 기능을 추가

Related to: TICO-162, TICO-209, TICO-225