### PR TITLE
[FEAT] 앱 테마 변경 화면 구현 (TICO-79)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -20,6 +20,7 @@ import com.tico.pomorodo.ui.home.view.HomeScreen
 import com.tico.pomorodo.ui.member.view.FollowListScreen
 import com.tico.pomorodo.ui.member.view.ModifyProfileScreen
 import com.tico.pomorodo.ui.member.view.MyPageScreen
+import com.tico.pomorodo.ui.setting.view.AppThemeScreen
 import com.tico.pomorodo.ui.setting.view.SettingScreen
 import com.tico.pomorodo.ui.splash.view.SplashScreen
 import com.tico.pomorodo.ui.timer.running.view.BreakTimerScreen
@@ -66,12 +67,16 @@ fun NavController.navigateToGroupMemberChoose(previousScreenType: String) =
 
 fun NavController.navigateToHistory() = navigate(MainNavigationDestination.HISTORY.name)
 
-fun NavController.navigateToModifyProfile() = navigate(MainNavigationDestination.MODIFY_PROFILE.name)
+fun NavController.navigateToModifyProfile() =
+    navigate(MainNavigationDestination.MODIFY_PROFILE.name)
 
 fun NavController.navigateToFollowListScreen() =
     navigate(MainNavigationDestination.FOLLOW.name)
 
 fun NavController.navigateToSettingScreen() = navigate(MainNavigationDestination.SETTING.name)
+
+fun NavController.navigateToAppThemeScreen(appThemeMode: String) =
+    navigate("${MainNavigationDestination.APP_THEME.name}/$appThemeMode")
 
 
 // home navigation - composable route
@@ -297,14 +302,30 @@ fun NavGraphBuilder.followListScreen() {
     }
 }
 
-fun NavGraphBuilder.settingScreen(navController: NavController) {
+fun NavGraphBuilder.settingScreen(navigateToAppThemeScreen: (String) -> Unit, popBackStack: () -> Unit) {
     composable(route = MainNavigationDestination.SETTING.name) {
         SettingScreen(
             navigateToModifyProfileScreen = { /*TODO*/ },
-            navigateToAppThemeScreen = { /*TODO*/ },
+            navigateToAppThemeScreen = navigateToAppThemeScreen,
             navigateToTermsOfUseScreen = { /*TODO*/ },
             navigateToPrivacyPolicyScreen = {},
-            popBackStack = { navController.popBackStack() }
+            popBackStack = { popBackStack() }
+        )
+    }
+}
+
+private const val APP_THEME_MODE = "AppThemeMode"
+
+fun NavGraphBuilder.appThemeScreen(popBackStack: () -> Unit) {
+    composable(
+        route = "${MainNavigationDestination.APP_THEME.name}/{$APP_THEME_MODE}",
+        arguments = listOf(navArgument(name = APP_THEME_MODE) { type = NavType.StringType })
+    ) { navBackStackEntry ->
+        val appThemeMode = navBackStackEntry.arguments?.getString(APP_THEME_MODE) ?: ""
+
+        AppThemeScreen(
+            initialSelectedMode = appThemeMode,
+            popBackStack = { popBackStack() }
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
@@ -47,4 +47,5 @@ enum class MainNavigationDestination {
     FOLLOW,
 
     SETTING,
+    APP_THEME,
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.navigation.addCategoryScreen
+import com.tico.pomorodo.navigation.appThemeScreen
 import com.tico.pomorodo.navigation.breakModeScreen
 import com.tico.pomorodo.navigation.categoryScreen
 import com.tico.pomorodo.navigation.concentrationModeScreen
@@ -28,6 +29,7 @@ import com.tico.pomorodo.navigation.infoCategoryScreen
 import com.tico.pomorodo.navigation.logInScreen
 import com.tico.pomorodo.navigation.modifyProfileScreen
 import com.tico.pomorodo.navigation.navigateToAddCategory
+import com.tico.pomorodo.navigation.navigateToAppThemeScreen
 import com.tico.pomorodo.navigation.navigateToBreakMode
 import com.tico.pomorodo.navigation.navigateToCategory
 import com.tico.pomorodo.navigation.navigateToConcentrationMode
@@ -62,7 +64,7 @@ fun MainScreen() {
         ) { innerPadding ->
             NavHost(
                 navController = mainNavController,
-                startDestination = MainNavigationDestination.SPLASH.name,
+                startDestination = MainNavigationDestination.HOME.name,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
@@ -138,7 +140,11 @@ fun MainScreen() {
 
                 followListScreen()
 
-                settingScreen(navController = mainNavController)
+                settingScreen(
+                    navigateToAppThemeScreen = mainNavController::navigateToAppThemeScreen,
+                    popBackStack = mainNavController::popBackStack
+                )
+                appThemeScreen(popBackStack = mainNavController::popBackStack)
             }
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/MyPageViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/viewmodel/MyPageViewModel.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor() : ViewModel() {
-    private var _name = MutableStateFlow("모카커피짱귀엽")
+    private var _name = MutableStateFlow("")
     val name: StateFlow<String> = _name.asStateFlow()
 
     private var _profile = MutableStateFlow<Uri?>(null)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/AppThemeScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/AppThemeScreen.kt
@@ -1,0 +1,119 @@
+package com.tico.pomorodo.ui.setting.view
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.RadioButtonColors
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.common.view.CustomTopAppBar
+import com.tico.pomorodo.ui.common.view.NoPaddingRadioButton
+import com.tico.pomorodo.ui.common.view.clickableWithRipple
+import com.tico.pomorodo.ui.theme.IC_OK
+import com.tico.pomorodo.ui.theme.IC_UNOK
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun AppThemeScreen(initialSelectedMode: String, popBackStack: () -> Unit) {
+    var enable by remember { mutableStateOf(false) }
+    var selectedMode by remember { mutableStateOf(initialSelectedMode) }
+
+    LaunchedEffect(key1 = selectedMode) {
+        if (!enable) {
+            enable = true
+        } else if (selectedMode == initialSelectedMode) {
+            enable = false
+        }
+    }
+
+    Surface(color = PomoroDoTheme.colorScheme.background) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            CustomTopAppBar(
+                titleTextId = R.string.title_app_theme,
+                iconString = IC_OK,
+                disableIconString = IC_UNOK,
+                descriptionId = R.string.content_ic_ok,
+                enabled = enable,
+                onClickedListener = {
+                    /*TODO: change app theme*/
+                    popBackStack()
+                },
+                onBackClickedListener = { popBackStack() }
+            )
+
+            AppThemeList(
+                modeList = appThemeMode,
+                selectedMode = selectedMode,
+                onSelectedModeChanged = { mode -> selectedMode = mode }
+            )
+        }
+    }
+}
+
+@Composable
+fun AppThemeList(
+    modeList: Map<String, Int>,
+    selectedMode: String,
+    onSelectedModeChanged: (String) -> Unit
+) {
+    Column(modifier = Modifier.padding(horizontal = 18.dp)) {
+        modeList.entries.forEachIndexed { index, entry ->
+            AppThemeItem(modeResId = entry.value, selected = (selectedMode == entry.key)) {
+                onSelectedModeChanged(entry.key)
+            }
+
+            if (index != modeList.size - 1)
+                HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)
+        }
+    }
+}
+
+@Composable
+fun AppThemeItem(@StringRes modeResId: Int, selected: Boolean, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clickableWithRipple { onClick() }
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(modeResId),
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Start,
+            style = PomoroDoTheme.typography.laundryGothicRegular16
+        )
+
+        val radioButtonColors = RadioButtonColors(
+            selectedColor = PomoroDoTheme.colorScheme.primaryContainer,
+            unselectedColor = PomoroDoTheme.colorScheme.dialogGray50,
+            disabledSelectedColor = Color.Unspecified,
+            disabledUnselectedColor = Color.Unspecified
+        )
+
+        NoPaddingRadioButton(
+            selected = selected,
+            onClick = onClick,
+            colors = radioButtonColors
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingMenu.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingMenu.kt
@@ -10,8 +10,8 @@ const val SYSTEM = "system"
 
 val appThemeMode = mapOf(
     LIGHT to R.string.content_app_theme_light,
-    DARK to (R.string.content_app_theme_dark),
-    SYSTEM to (R.string.content_app_theme_system)
+    DARK to R.string.content_app_theme_dark,
+    SYSTEM to R.string.content_app_theme_system
 )
 
 enum class SettingMenu(

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingScreen.kt
@@ -28,7 +28,7 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Composable
 fun SettingScreen(
     navigateToModifyProfileScreen: () -> Unit,
-    navigateToAppThemeScreen: () -> Unit,
+    navigateToAppThemeScreen: (String) -> Unit,
     navigateToTermsOfUseScreen: () -> Unit,
     navigateToPrivacyPolicyScreen: () -> Unit,
     popBackStack: () -> Unit
@@ -58,18 +58,23 @@ fun SettingScreen(
     }
 }
 
+sealed class MenuNavigateFunction {
+    data class StringFunction(val function: (String) -> Unit) : MenuNavigateFunction()
+    data class UnitFunction(val function: () -> Unit) : MenuNavigateFunction()
+}
+
 @Composable
 fun SettingMenuList(
     navigateToModifyProfileScreen: () -> Unit,
-    navigateToAppThemeScreen: () -> Unit,
+    navigateToAppThemeScreen: (String) -> Unit,
     navigateToTermsOfUseScreen: () -> Unit,
     navigateToPrivacyPolicyScreen: () -> Unit
 ) {
-    val menuList: Map<SettingMenu, (() -> Unit)?> = mapOf(
-        SettingMenu.MODIFY_PROFILE to navigateToModifyProfileScreen,
-        SettingMenu.APP_THEME to navigateToAppThemeScreen,
-        SettingMenu.TERMS_OF_USE to navigateToTermsOfUseScreen,
-        SettingMenu.PRIVACY_POLICY to navigateToPrivacyPolicyScreen,
+    val menuList: Map<SettingMenu, MenuNavigateFunction?> = mapOf(
+        SettingMenu.MODIFY_PROFILE to MenuNavigateFunction.UnitFunction(navigateToModifyProfileScreen),
+        SettingMenu.APP_THEME to MenuNavigateFunction.StringFunction(navigateToAppThemeScreen),
+        SettingMenu.TERMS_OF_USE to MenuNavigateFunction.UnitFunction(navigateToTermsOfUseScreen),
+        SettingMenu.PRIVACY_POLICY to MenuNavigateFunction.UnitFunction(navigateToPrivacyPolicyScreen),
         SettingMenu.APP_VERSION to null
     )
 
@@ -93,10 +98,19 @@ fun SettingMenuItem(
     @StringRes menuStringResId: Int,
     menuType: SettingMenuType,
     content: Any? = null,
-    onClick: (() -> Unit)? = null
+    onClick: MenuNavigateFunction? = null
 ) {
     val modifier =
-        if (onClick != null) Modifier.clickableWithRipple { onClick() } else Modifier
+        if (onClick != null) {
+            Modifier.clickableWithRipple {
+                when (onClick) {
+                    is MenuNavigateFunction.UnitFunction -> onClick.function()
+                    is MenuNavigateFunction.StringFunction -> onClick.function(content as String)
+                }
+            }
+        } else {
+            Modifier
+        }
 
     Row(
         modifier = modifier

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -191,7 +191,9 @@
     <string name="title_terms_of_use">이용 약관</string>
     <string name="title_privacy_policy">개인 정보 처리 방침</string>
     <string name="title_app_version">앱 버전</string>
-    <string name="content_app_theme_light">라이트 모드</string>
+    <string name="content_app_theme_light">라이트</string>
+    <string name="content_app_theme_dark">다크</string>
+    <string name="content_app_theme_system">시스템 설정</string>
 
     // common
     <string name="content_next">다음</string>
@@ -211,6 +213,4 @@
     <string name="content_unfollow">언팔로우</string>
     <string name="title_following">팔로잉</string>
     <string name="title_follower">팔로워</string>
-    <string name="content_app_theme_dark">다크 모드</string>
-    <string name="content_app_theme_system">시스템 설정</string>
 </resources>


### PR DESCRIPTION
### 추가된 내용
- 앱 테마 변경 화면 구현
- 앱 테마 변경 화면 연결
  - 환경 설정 화면에서 화면 전환 시 현재 설정된 모드를 String으로 전송함.

Fixes: TICO-79
Related to: TICO-77