### PR TITLE
[FEAT] 팔로잉 목록 조회 정렬 및 사용자 정보 조회 로직 개선 (TICO-285)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -34,7 +34,7 @@ public class FollowController {
      * @return 성공 시 성공 메시지를 포함한 SuccessResponseDTO 반환
      */
     @Operation(
-            summary = "특정 사용자 팔로우",
+            summary = "현재 사용자가 특정 사용자를 팔로우",
             description = "현재 인증된 사용자가 특정 사용자를 팔로우합니다. <br>" +
                     "팔로우가 성공하면 성공 메시지를 반환합니다. " +
                     "팔로우할 사용자가 존재하지 않거나 이미 팔로우 중인 경우 예외가 발생할 수 있습니다."
@@ -67,9 +67,9 @@ public class FollowController {
      * @return 사용자가 팔로우 중인 사용자 목록을 포함한 List<FollowUserDTO> 반환
      */
     @Operation(
-            summary = "현재 사용자 팔로우 목록 조회",
+            summary = "현재 사용자의 팔로우 목록 조회",
             description = "현재 인증된 사용자가 팔로우 중인 사용자 목록을 조회합니다. <br>" +
-                    "성공적으로 조회되면 사용자가 팔로우 중인 모든 사용자 정보를 포함한 리스트를 반환합니다."
+                    "성공적으로 조회되면 사용자가 팔로우 중인 모든 사용자 정보를 포함한 리스트를 가나다 순으로 반환합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "팔로우 목록 조회 성공"),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.domain.user.controller;
 
+import com.tico.pomoro_do.domain.user.dto.response.FollowUserDTO;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailDTO;
 import com.tico.pomoro_do.domain.user.service.UserService;
 import com.tico.pomoro_do.global.auth.CustomUserDetails;
@@ -30,7 +31,9 @@ public class UserController {
      */
     @Operation(summary = "현재 사용자 정보 조회", description = "인증된 사용자의 상세 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponseDTO<UserDetailDTO>> getMyDetail(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ResponseEntity<SuccessResponseDTO<UserDetailDTO>> getMyDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
 
         UserDetailDTO userDetailResponse = userService.getMyDetail(customUserDetails.getUsername());
         SuccessResponseDTO<UserDetailDTO> successResponse = SuccessResponseDTO.<UserDetailDTO>builder()
@@ -44,19 +47,23 @@ public class UserController {
     }
 
     /**
-     * 주어진 사용자 ID에 대한 상세 정보를 조회합니다.
+     * 특정 사용자의 상세 정보 및 팔로우 상태를 조회합니다.
      *
      * @param userId 조회할 사용자 ID
-     * @return 성공 시 사용자 상세 정보가 담긴 SuccessResponseDTO 반환
+     * @return 성공 시 사용자 정보와 팔로우 상태가 담긴 SuccessResponseDTO 반환
      */
-    @Operation(summary = "특정 사용자 정보 조회", description = "주어진 사용자 ID에 대한 상세 정보를 조회합니다.")
+    @Operation(summary = "특정 사용자 정보 조회", description = "주어진 사용자 ID에 대한 상세 정보 및 팔로우 상태를 조회합니다.")
     @GetMapping("/{userId}")
-    public ResponseEntity<SuccessResponseDTO<UserDetailDTO>> getUserDetail(@PathVariable Long userId) {
-        UserDetailDTO userDetailResponse = userService.getUserDetail(userId);
-        SuccessResponseDTO<UserDetailDTO> successResponse = SuccessResponseDTO.<UserDetailDTO>builder()
+    public ResponseEntity<SuccessResponseDTO<FollowUserDTO>> getUserDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long userId
+    ) {
+        String username = customUserDetails.getUsername();
+        FollowUserDTO response = userService.getUserDetail(username, userId);
+        SuccessResponseDTO<FollowUserDTO> successResponse = SuccessResponseDTO.<FollowUserDTO>builder()
                 .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
-                .data(userDetailResponse)
+                .data(response)
                 .build();
 
         return ResponseEntity.ok(successResponse);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -62,20 +63,26 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public List<FollowUserDTO> getFollowingList(String username) {
-
+        // 사용자 조회
         User user = userService.findByUsername(username);
+        // 사용자와 관련된 팔로우 목록을 조회
         List<Follow> followList = followRepository.findBySender(user);
 
-        return followList.isEmpty() ? Collections.emptyList() :
-                followList.stream()
+        // 팔로우 리스트가 비어 있으면 빈 리스트 반환
+        if (followList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // FollowUserDTO 리스트 생성 및 변환
+        return followList.stream()
                 .map(follow -> FollowUserDTO.builder()
                         .userId(follow.getReceiver().getId())
                         .nickname(follow.getReceiver().getNickname())
                         .profileImageUrl(follow.getReceiver().getProfileImageUrl())
                         .following(true)
                         .build())
+                .sorted(Comparator.comparing(FollowUserDTO::getNickname)) // 닉네임으로 정렬
                 .collect(Collectors.toList());
-
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.domain.user.service;
 
+import com.tico.pomoro_do.domain.user.dto.response.FollowUserDTO;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailDTO;
 import com.tico.pomoro_do.domain.user.entity.User;
 
@@ -15,7 +16,7 @@ public interface UserService {
     User findByUserId(Long userId);
 
     // 특정 유저 조회
-    UserDetailDTO getUserDetail(Long userId);
+    FollowUserDTO getUserDetail(String username, Long userId);
 
     // 유저 삭제
     void deleteUser(String username, String deviceId, String refreshHeader);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.domain.user.service;
 
+import com.tico.pomoro_do.domain.user.dto.response.FollowUserDTO;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailDTO;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.domain.user.repository.FollowRepository;
@@ -41,22 +42,22 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public UserDetailDTO getUserDetail(Long userId) {
+    public FollowUserDTO getUserDetail(String username, Long userId) {
 
+        // 주어진 username에 해당하는 현재 사용자 ID 조회
+        Long myUserId = findByUsername(username).getId();
+        // 주어진 userId에 해당하는 특정 사용자 정보 조회
         User user = findByUserId(userId);
 
-        // 내가 팔로우하는 사람의 수 계산
-        int followingCount = followRepository.countBySender(user);
-        // 나를 팔로우하는 사람의 수 계산
-        int followerCount = followRepository.countByReceiver(user);
+        // 현재 사용자가 해당 특정 사용자를 팔로우하고 있는지 여부 확인
+        boolean isFollowing = followRepository.existsBySenderIdAndReceiverId(myUserId, userId);
 
-        return UserDetailDTO.builder()
+        // 사용자 정보 및 팔로우 상태를 포함한 DTO 반환
+        return FollowUserDTO.builder()
                 .userId(user.getId())
-                .username(user.getUsername())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
-                .followingCount(followingCount)
-                .followerCount(followerCount)
+                .following(isFollowing)
                 .build();
     }
 


### PR DESCRIPTION
- 팔로잉 목록 조회 API에 닉네임 기준으로 가나다 순 정렬 기능 추가
- 특정 사용자 정보 조회 시 팔로우 여부 포함하도록 로직 개선
- 팔로워 및 팔로잉 수를 계산하는 기존 로직 제거

Ref: TICO-249, TICO-251
Related to: TICO-248, TICO-162