### PR TITLE
[FEAT] 현재 사용자의 팔로워 목록 조회 API 구현 (TICO-279)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -89,4 +89,23 @@ public class FollowController {
         return ResponseEntity.ok(successResponse);
     }
 
+    @Operation(
+            summary = "현재 사용자의 팔로워 목록 조회",
+            description = "현재 인증된 사용자를 팔로우 중인 사용자 목록을 조회합니다. <br>" +
+                    "성공적으로 조회되면 사용자가 팔로우 중인 모든 사용자 정보를 포함한 리스트를 가나다 순으로 반환합니다."
+    )
+    @GetMapping("/me/followers")
+    public ResponseEntity<SuccessResponseDTO<List<FollowUserDTO>>> getFollowersList(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        String username = customUserDetails.getUsername();
+        List<FollowUserDTO> followersList = followService.getFollowersList(username);
+        SuccessResponseDTO<List<FollowUserDTO>> successResponse = SuccessResponseDTO.<List<FollowUserDTO>>builder()
+                .status(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getHttpStatus().value())
+                .message(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getMessage())
+                .data(followersList)
+                .build();
+        return ResponseEntity.ok(successResponse);
+    }
+
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -69,7 +69,7 @@ public class FollowController {
     @Operation(
             summary = "현재 사용자의 팔로우 목록 조회",
             description = "현재 인증된 사용자가 팔로우 중인 사용자 목록을 조회합니다. <br>" +
-                    "성공적으로 조회되면 사용자가 팔로우 중인 모든 사용자 정보를 포함한 리스트를 가나다 순으로 반환합니다."
+                    "성공적으로 조회되면 팔로우한 사용자 정보를 포함한 리스트를 닉네임 기준으로 오름차순 정렬하여 반환합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "팔로우 목록 조회 성공"),
@@ -81,30 +81,44 @@ public class FollowController {
     ) {
         String username = customUserDetails.getUsername();
         List<FollowUserDTO> followingList = followService.getFollowingList(username);
+
         SuccessResponseDTO<List<FollowUserDTO>> successResponse = SuccessResponseDTO.<List<FollowUserDTO>>builder()
                 .status(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getMessage())
                 .data(followingList)
                 .build();
+
         return ResponseEntity.ok(successResponse);
     }
 
+    /**
+     * 사용자를 팔로우 중인 사용자 목록을 조회하는 API
+     *
+     * @param customUserDetails 현재 인증된 사용자의 정보
+     * @return 사용자를 팔로우 중인 사용자 목록을 포함한 List<FollowUserDTO> 반환
+     */
     @Operation(
             summary = "현재 사용자의 팔로워 목록 조회",
             description = "현재 인증된 사용자를 팔로우 중인 사용자 목록을 조회합니다. <br>" +
-                    "성공적으로 조회되면 사용자가 팔로우 중인 모든 사용자 정보를 포함한 리스트를 가나다 순으로 반환합니다."
+                    "성공적으로 조회되면 팔로워 정보를 포함한 리스트를 닉네임 기준으로 오름차순 정렬하여 반환합니다."
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping("/me/followers")
     public ResponseEntity<SuccessResponseDTO<List<FollowUserDTO>>> getFollowersList(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         String username = customUserDetails.getUsername();
         List<FollowUserDTO> followersList = followService.getFollowersList(username);
+
         SuccessResponseDTO<List<FollowUserDTO>> successResponse = SuccessResponseDTO.<List<FollowUserDTO>>builder()
                 .status(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getMessage())
                 .data(followersList)
                 .build();
+
         return ResponseEntity.ok(successResponse);
     }
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminDTO.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminDTO.java
@@ -12,9 +12,11 @@ public class AdminDTO {
 
     @Email
     @NotBlank(message = "이메일을 입력해주세요.")
+    @Schema(description = "아이디", example = "chadoll@pomorodo.shop")
     private String username;
 
     @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
     @NotBlank(message = "닉네임을 입력해주세요.")
+    @Schema(description = "닉네임", example = "chadoll")
     private String nickname;
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/FollowRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/FollowRepository.java
@@ -13,6 +13,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     // 내가 팔로우하고 있는 사용자 목록을 조회
     List<Follow> findBySender(User sender);
+    // 나를 팔로우하고 있는 사용자 목록을 조회
+    List<Follow> findByReceiver(User receiver);
 
     // 내가 팔로우하는 사람의 수
     int countBySender(User sender);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/FollowRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/FollowRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     // 팔로우 중인지 체크
-    boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
+    boolean existsBySenderIdAndReceiverId(Long currentUserId, Long targetUserId);
 
     // 내가 팔로우하고 있는 사용자 목록을 조회
     List<Follow> findBySender(User sender);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
@@ -11,6 +11,8 @@ public interface FollowService {
 
     // 내가 팔로우하고 있는 사용자 목록을 조회
     List<FollowUserDTO> getFollowingList(String username);
+    // 나를 팔로우하고 있는 사용자 목록을 조회
+    List<FollowUserDTO> getFollowersList(String username);
 
     // 특정 사용자가 다른 사용자를 팔로우하고 있는지 확인
     boolean isFollowedByUser(Long senderId, Long receiverId);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
@@ -85,6 +85,25 @@ public class FollowServiceImpl implements FollowService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<FollowUserDTO> getFollowersList(String username) {
+        // 사용자 조회
+        User user = userService.findByUsername(username);
+        // 사용자와 관련된 팔로우 목록을 조회
+        List<Follow> followList = followRepository.findByReceiver(user);
+        // FollowUserDTO 리스트 생성 및 변환
+        return followList.stream()
+                .map(follow -> FollowUserDTO.builder()
+                        .userId(follow.getSender().getId())
+                        .nickname(follow.getSender().getNickname())
+                        .profileImageUrl(follow.getSender().getProfileImageUrl())
+                        .following(isFollowedByUser(user.getId(), follow.getSender().getId()))
+                        .build())
+                .sorted(Comparator.comparing(FollowUserDTO::getNickname))
+                .collect(Collectors.toList());
+    }
+
+
     /**
      * 특정 사용자가 다른 사용자를 팔로우하고 있는지 확인
      *
@@ -96,4 +115,5 @@ public class FollowServiceImpl implements FollowService {
     public boolean isFollowedByUser(Long senderId, Long receiverId) {
         return followRepository.existsBySenderIdAndReceiverId(senderId, receiverId);
     }
+
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/SuccessCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/SuccessCode.java
@@ -17,7 +17,9 @@ public enum SuccessCode {
     USER_FETCH_SUCCESS(HttpStatus.OK, "회원 조회에 성공했습니다."),
     USER_DELETION_SUCCESS(HttpStatus.OK, "회원 탈퇴가 성공적으로 처리되었습니다."),
     FOLLOW_SUCCESS(HttpStatus.CREATED, "팔로우에 성공했습니다."),
-    FOLLOWING_LIST_FETCH_SUCCESS(HttpStatus.OK, "내가 팔로우하고 있는 사용자 목록을 조회에 성공했습니다."),
+    FOLLOWING_LIST_FETCH_SUCCESS(HttpStatus.OK, "내가 팔로우하고 있는 사용자 목록 조회에 성공했습니다."),
+    FOLLOWERS_LIST_FETCH_SUCCESS(HttpStatus.OK, "나를 팔로우하고 있는 사용자 목록 조회에 성공했습니다."),
+    UNFOLLOW_SUCCESS(HttpStatus.OK, "언팔로우에 성공했습니다."),
 
     //토큰
     ACCESS_TOKEN_REISSUED(HttpStatus.OK,  "액세스 토큰이 성공적으로 재발급되었습니다."),


### PR DESCRIPTION
- 현재 사용자의 팔로워 목록 조회 기능을 추가
- 팔로우 및 팔로워 목록 조회 메서드 통합

Related to: TICO-248