### PR TITLE
[FEAT] 팔로우 UI 수정 (TICO-316)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -31,6 +31,7 @@ fun AppNavHost(
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory
         )
+        followScreen()
         myInfoScreen(
             navigateToModifyProfile = navigateToModifyProfile,
             navigateToFollowListScreen = navigateToFollowListScreen,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -15,7 +15,6 @@ fun AppNavHost(
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     navigateToModifyProfile: () -> Unit,
-    navigateToFollowListScreen: () -> Unit,
     navigateToSettingScreen: () -> Unit,
     setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit,
 ) {
@@ -34,7 +33,6 @@ fun AppNavHost(
         followScreen()
         myInfoScreen(
             navigateToModifyProfile = navigateToModifyProfile,
-            navigateToFollowListScreen = navigateToFollowListScreen,
             navigateToSettingScreen = navigateToSettingScreen
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -35,6 +35,9 @@ fun NavController.navigateToTimer(navOptions: NavOptions) =
 fun NavController.navigateToTodo(navOptions: NavOptions) =
     navigate(BottomNavigationDestination.TODO.name, navOptions)
 
+fun NavController.navigateToFollow(navOptions: NavOptions) =
+    navigate(BottomNavigationDestination.FOLLOW.name, navOptions)
+
 fun NavController.navigateToMyInfo(navOptions: NavOptions) =
     navigate(BottomNavigationDestination.MY_INFO.name, navOptions)
 
@@ -100,6 +103,12 @@ fun NavGraphBuilder.todoScreen(
             navigateToCategory = navigateToCategory,
             navigateToHistory = navigateToHistory
         )
+    }
+}
+
+fun NavGraphBuilder.followScreen() {
+    composable(route = BottomNavigationDestination.FOLLOW.name) {
+        com.tico.pomorodo.ui.follow.view.FollowListScreen()
     }
 }
 
@@ -302,7 +311,10 @@ fun NavGraphBuilder.followListScreen() {
     }
 }
 
-fun NavGraphBuilder.settingScreen(navigateToAppThemeScreen: (String) -> Unit, popBackStack: () -> Unit) {
+fun NavGraphBuilder.settingScreen(
+    navigateToAppThemeScreen: (String) -> Unit,
+    popBackStack: () -> Unit
+) {
     composable(route = MainNavigationDestination.SETTING.name) {
         SettingScreen(
             navigateToModifyProfileScreen = { /*TODO*/ },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -17,7 +17,6 @@ import com.tico.pomorodo.ui.category.view.GroupMemberChooseRoute
 import com.tico.pomorodo.ui.category.view.InfoCategoryScreenRoute
 import com.tico.pomorodo.ui.history.view.HistoryRoute
 import com.tico.pomorodo.ui.home.view.HomeScreen
-import com.tico.pomorodo.ui.member.view.FollowListScreen
 import com.tico.pomorodo.ui.member.view.ModifyProfileScreen
 import com.tico.pomorodo.ui.member.view.MyPageScreen
 import com.tico.pomorodo.ui.setting.view.AppThemeScreen
@@ -73,9 +72,6 @@ fun NavController.navigateToHistory() = navigate(MainNavigationDestination.HISTO
 fun NavController.navigateToModifyProfile() =
     navigate(MainNavigationDestination.MODIFY_PROFILE.name)
 
-fun NavController.navigateToFollowListScreen() =
-    navigate(MainNavigationDestination.FOLLOW.name)
-
 fun NavController.navigateToSettingScreen() = navigate(MainNavigationDestination.SETTING.name)
 
 fun NavController.navigateToAppThemeScreen(appThemeMode: String) =
@@ -114,13 +110,11 @@ fun NavGraphBuilder.followScreen() {
 
 fun NavGraphBuilder.myInfoScreen(
     navigateToModifyProfile: () -> Unit,
-    navigateToFollowListScreen: () -> Unit,
     navigateToSettingScreen: () -> Unit,
 ) {
     composable(route = BottomNavigationDestination.MY_INFO.name) {
         MyPageScreen(
             navigateToModifyProfile = navigateToModifyProfile,
-            navigateToFollowListScreen = navigateToFollowListScreen,
             navigateToSettingScreen = navigateToSettingScreen
         )
     }
@@ -169,7 +163,6 @@ fun NavGraphBuilder.homeScreen(
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     navigateToModifyProfile: () -> Unit,
-    navigateToFollowListScreen: () -> Unit,
     navigateToSettingScreen: () -> Unit
 ) {
     composable(route = MainNavigationDestination.HOME.name) {
@@ -180,7 +173,6 @@ fun NavGraphBuilder.homeScreen(
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory,
             navigateToModifyProfile = navigateToModifyProfile,
-            navigateToFollowListScreen = navigateToFollowListScreen,
             navigateToSettingScreen = navigateToSettingScreen
         )
     }
@@ -302,12 +294,6 @@ fun NavGraphBuilder.groupMemberChooseScreen(
 fun NavGraphBuilder.modifyProfileScreen(navController: NavController) {
     composable(route = MainNavigationDestination.MODIFY_PROFILE.name) { navBackStackEntry ->
         ModifyProfileScreen(navController = navController, navBackStackEntry = navBackStackEntry)
-    }
-}
-
-fun NavGraphBuilder.followListScreen() {
-    composable(route = MainNavigationDestination.FOLLOW.name) {
-        FollowListScreen()
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
@@ -2,6 +2,7 @@ package com.tico.pomorodo.navigation
 
 import androidx.annotation.StringRes
 import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.theme.IC_BOTTOM_FOLLOW
 import com.tico.pomorodo.ui.theme.IC_BOTTOM_MY_INFO
 import com.tico.pomorodo.ui.theme.IC_BOTTOM_TIMER
 import com.tico.pomorodo.ui.theme.IC_BOTTOM_TODO
@@ -17,6 +18,10 @@ enum class BottomNavigationDestination(
     TODO(
         iconString = IC_BOTTOM_TODO,
         iconTextId = R.string.title_todo,
+    ),
+    FOLLOW(
+        iconString = IC_BOTTOM_FOLLOW,
+        iconTextId = R.string.title_follow,
     ),
     MY_INFO(
         iconString = IC_BOTTOM_MY_INFO,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
@@ -49,7 +49,6 @@ enum class MainNavigationDestination {
     HISTORY,
 
     MODIFY_PROFILE,
-    FOLLOW,
 
     SETTING,
     APP_THEME,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -20,7 +20,6 @@ import com.tico.pomorodo.navigation.appThemeScreen
 import com.tico.pomorodo.navigation.breakModeScreen
 import com.tico.pomorodo.navigation.categoryScreen
 import com.tico.pomorodo.navigation.concentrationModeScreen
-import com.tico.pomorodo.navigation.followListScreen
 import com.tico.pomorodo.navigation.getState
 import com.tico.pomorodo.navigation.groupMemberChooseScreen
 import com.tico.pomorodo.navigation.historyScreen
@@ -33,7 +32,6 @@ import com.tico.pomorodo.navigation.navigateToAppThemeScreen
 import com.tico.pomorodo.navigation.navigateToBreakMode
 import com.tico.pomorodo.navigation.navigateToCategory
 import com.tico.pomorodo.navigation.navigateToConcentrationMode
-import com.tico.pomorodo.navigation.navigateToFollowListScreen
 import com.tico.pomorodo.navigation.navigateToGroupMemberChoose
 import com.tico.pomorodo.navigation.navigateToHistory
 import com.tico.pomorodo.navigation.navigateToHome
@@ -100,7 +98,6 @@ fun MainScreen() {
                     navigateToAddCategory = mainNavController::navigateToAddCategory,
                     navigateToHistory = mainNavController::navigateToHistory,
                     navigateToModifyProfile = mainNavController::navigateToModifyProfile,
-                    navigateToFollowListScreen = mainNavController::navigateToFollowListScreen,
                     navigateToSettingScreen = mainNavController::navigateToSettingScreen
                 )
 
@@ -137,8 +134,6 @@ fun MainScreen() {
                 historyScreen(navigateToBack = mainNavController::popBackStack)
 
                 modifyProfileScreen(navController = mainNavController)
-
-                followListScreen()
 
                 settingScreen(
                     navigateToAppThemeScreen = mainNavController::navigateToAppThemeScreen,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomTopAppBar.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/CustomTopAppBar.kt
@@ -76,7 +76,7 @@ fun CustomTopAppBar(
 }
 
 @Composable
-fun CustomTopAppBarWithSingleButton(
+fun CustomTopAppBarWithNavigation(
     title: String,
     navigationAction: () -> Unit,
     top: Int = 0,
@@ -104,6 +104,41 @@ fun CustomTopAppBarWithSingleButton(
             color = PomoroDoTheme.colorScheme.onBackground,
             textAlign = TextAlign.Center,
             style = PomoroDoTheme.typography.laundryGothicBold20
+        )
+    }
+}
+
+@Composable
+fun CustomTopAppBarWithRightButton(
+    title: String,
+    iconString: String,
+    @StringRes iconDescriptionId: Int,
+    onClickedListener: () -> Unit,
+    top: Int = 0,
+    bottom: Int = 0,
+    start: Int = 0,
+    end: Int = 0
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = start.dp, end = end.dp, top = top.dp, bottom = bottom.dp),
+        contentAlignment = Alignment.CenterEnd
+    ) {
+        Text(
+            text = title,
+            modifier = Modifier.fillMaxWidth(),
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            style = PomoroDoTheme.typography.laundryGothicBold20
+        )
+
+        SimpleIconButton(
+            size = 28,
+            imageVector = requireNotNull(PomoroDoTheme.iconPack[iconString]),
+            contentDescriptionId = iconDescriptionId,
+            enabled = true,
+            onClickedListener = onClickedListener
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
@@ -1,4 +1,4 @@
-package com.tico.pomorodo.ui.member.view
+package com.tico.pomorodo.ui.follow.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -44,12 +45,14 @@ import com.skydoves.landscapist.glide.GlideImage
 import com.tico.pomorodo.R
 import com.tico.pomorodo.domain.model.Follow
 import com.tico.pomorodo.ui.common.view.CustomTextButton
-import com.tico.pomorodo.ui.common.view.CustomTopAppBarWithSingleButton
+import com.tico.pomorodo.ui.common.view.CustomTopAppBarWithRightButton
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
 import com.tico.pomorodo.ui.member.viewmodel.FollowViewModel
+import com.tico.pomorodo.ui.theme.IC_ADD_CATEGORY
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import kotlinx.coroutines.launch
 
+@Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun FollowListScreen() {
     val followViewModel: FollowViewModel = hiltViewModel()
@@ -62,9 +65,11 @@ fun FollowListScreen() {
     var selectedIndex by remember { mutableIntStateOf(0) }
 
     Column(modifier = Modifier.background(color = PomoroDoTheme.colorScheme.background)) {
-        CustomTopAppBarWithSingleButton(
+        CustomTopAppBarWithRightButton(
             title = stringResource(R.string.title_follow),
-            navigationAction = { /*TODO: top app bar - pop back stack*/ },
+            iconString = IC_ADD_CATEGORY,
+            iconDescriptionId = R.string.content_ic_add_follower,
+            onClickedListener = { /*TODO: top app bar - pop back stack*/ },
             top = 24,
             bottom = 14,
             start = 16,
@@ -257,7 +262,7 @@ fun FollowItem(
         GlideImage(
             imageModel = { user.profileUrl },
             modifier = Modifier
-                .size(48.dp)
+                .size(40.dp)
                 .clip(shape = CircleShape),
             requestOptions = { RequestOptions().diskCacheStrategy(DiskCacheStrategy.AUTOMATIC) },
             imageOptions = ImageOptions(
@@ -268,9 +273,10 @@ fun FollowItem(
 
         Text(
             text = user.name,
+            modifier = Modifier.padding(start = 16.dp),
             color = PomoroDoTheme.colorScheme.onBackground,
             textAlign = TextAlign.Start,
-            style = PomoroDoTheme.typography.laundryGothicRegular18
+            style = PomoroDoTheme.typography.laundryGothicRegular16
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -279,9 +285,9 @@ fun FollowItem(
             text = buttonText,
             containerColor = buttonContainerColor,
             contentColor = buttonContentColor,
-            textStyle = PomoroDoTheme.typography.laundryGothicRegular16,
-            verticalPadding = 8.dp,
-            horizontalPadding = 15.dp,
+            textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
+            verticalPadding = 6.dp,
+            horizontalPadding = 12.dp,
             onClick = onClick
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navOptions
 import com.tico.pomorodo.navigation.BottomNavigationDestination
+import com.tico.pomorodo.navigation.navigateToFollow
 import com.tico.pomorodo.navigation.navigateToMyInfo
 import com.tico.pomorodo.navigation.navigateToTimer
 import com.tico.pomorodo.navigation.navigateToTodo
@@ -31,6 +32,7 @@ class AppState(val navController: NavHostController) {
         when (topLevelDestination) {
             BottomNavigationDestination.TIMER -> navController.navigateToTimer(navOptions)
             BottomNavigationDestination.TODO -> navController.navigateToTodo(navOptions)
+            BottomNavigationDestination.FOLLOW -> navController.navigateToFollow(navOptions)
             BottomNavigationDestination.MY_INFO -> navController.navigateToMyInfo(navOptions)
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/HomeScreen.kt
@@ -17,7 +17,6 @@ fun HomeScreen(
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     navigateToModifyProfile: () -> Unit,
-    navigateToFollowListScreen: () -> Unit,
     navigateToSettingScreen: () -> Unit,
     setTimerState: (concentrationTime: Int, breakTime: Int) -> Unit
 ) {
@@ -37,7 +36,6 @@ fun HomeScreen(
             navigateToAddCategory = navigateToAddCategory,
             navigateToHistory = navigateToHistory,
             navigateToModifyProfile = navigateToModifyProfile,
-            navigateToFollowListScreen = navigateToFollowListScreen,
             navigateToSettingScreen = navigateToSettingScreen,
             setTimerState = setTimerState,
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/darkiconpack/IcBottomFollowDark.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/darkiconpack/IcBottomFollowDark.kt
@@ -1,0 +1,122 @@
+package com.tico.pomorodo.ui.iconpack.darkiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val IcBottomFollowDark: ImageVector
+    get() {
+        if (_icBottomFollowDark != null) {
+            return _icBottomFollowDark!!
+        }
+        _icBottomFollowDark = Builder(
+            name = "IcBottomFollowDark", defaultWidth = 22.0.dp,
+            defaultHeight = 22.0.dp, viewportWidth = 22.0f, viewportHeight = 22.0f
+        ).apply {
+            group {
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(11.0f, 15.8125f)
+                    curveTo(12.3289f, 15.8125f, 13.4062f, 14.7352f, 13.4062f, 13.4062f)
+                    curveTo(13.4062f, 12.0773f, 12.3289f, 11.0f, 11.0f, 11.0f)
+                    curveTo(9.6711f, 11.0f, 8.5938f, 12.0773f, 8.5938f, 13.4062f)
+                    curveTo(8.5938f, 14.7352f, 9.6711f, 15.8125f, 11.0f, 15.8125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(11.0f, 15.8125f)
+                    curveTo(9.9088f, 15.8215f, 8.8648f, 16.259f, 8.0931f, 17.0306f)
+                    curveTo(7.3215f, 17.8023f, 6.884f, 18.8463f, 6.875f, 19.9375f)
+                    verticalLineTo(20.625f)
+                    horizontalLineTo(15.125f)
+                    verticalLineTo(19.9375f)
+                    curveTo(15.116f, 18.8463f, 14.6785f, 17.8023f, 13.9069f, 17.0306f)
+                    curveTo(13.1352f, 16.259f, 12.0912f, 15.8215f, 11.0f, 15.8125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(17.875f, 5.5f)
+                    curveTo(19.0141f, 5.5f, 19.9375f, 4.5766f, 19.9375f, 3.4375f)
+                    curveTo(19.9375f, 2.2984f, 19.0141f, 1.375f, 17.875f, 1.375f)
+                    curveTo(16.7359f, 1.375f, 15.8125f, 2.2984f, 15.8125f, 3.4375f)
+                    curveTo(15.8125f, 4.5766f, 16.7359f, 5.5f, 17.875f, 5.5f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(21.3125f, 9.625f)
+                    curveTo(21.3125f, 7.0469f, 19.7656f, 5.5f, 17.875f, 5.5f)
+                    curveTo(15.9844f, 5.5f, 14.4375f, 7.0469f, 14.4375f, 9.625f)
+                    horizontalLineTo(21.3125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(4.125f, 5.5f)
+                    curveTo(5.2641f, 5.5f, 6.1875f, 4.5766f, 6.1875f, 3.4375f)
+                    curveTo(6.1875f, 2.2984f, 5.2641f, 1.375f, 4.125f, 1.375f)
+                    curveTo(2.9859f, 1.375f, 2.0625f, 2.2984f, 2.0625f, 3.4375f)
+                    curveTo(2.0625f, 4.5766f, 2.9859f, 5.5f, 4.125f, 5.5f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(7.5625f, 9.625f)
+                    curveTo(7.5625f, 7.0469f, 6.0156f, 5.5f, 4.125f, 5.5f)
+                    curveTo(2.2344f, 5.5f, 0.6875f, 7.0469f, 0.6875f, 9.625f)
+                    horizontalLineTo(7.5625f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFFF5F5F5)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(4.125f, 11.6875f)
+                    lineTo(6.875f, 14.4375f)
+                    moveTo(17.875f, 11.6875f)
+                    lineTo(15.125f, 14.4375f)
+                    moveTo(8.25f, 4.8125f)
+                    horizontalLineTo(13.75f)
+                }
+            }
+        }
+            .build()
+        return _icBottomFollowDark!!
+    }
+
+private var _icBottomFollowDark: ImageVector? = null

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/lighticonpack/IcBottomFollowLight.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/iconpack/lighticonpack/IcBottomFollowLight.kt
@@ -1,0 +1,122 @@
+package com.tico.pomorodo.ui.iconpack.lighticonpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val IcBottomFollowLight: ImageVector
+    get() {
+        if (_icBottomFollowLight != null) {
+            return _icBottomFollowLight!!
+        }
+        _icBottomFollowLight = Builder(
+            name = "IcBottomFollowLight", defaultWidth = 22.0.dp,
+            defaultHeight = 22.0.dp, viewportWidth = 22.0f, viewportHeight = 22.0f
+        ).apply {
+            group {
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(11.0f, 15.8125f)
+                    curveTo(12.3289f, 15.8125f, 13.4062f, 14.7352f, 13.4062f, 13.4062f)
+                    curveTo(13.4062f, 12.0773f, 12.3289f, 11.0f, 11.0f, 11.0f)
+                    curveTo(9.6711f, 11.0f, 8.5938f, 12.0773f, 8.5938f, 13.4062f)
+                    curveTo(8.5938f, 14.7352f, 9.6711f, 15.8125f, 11.0f, 15.8125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(11.0f, 15.8125f)
+                    curveTo(9.9088f, 15.8215f, 8.8648f, 16.259f, 8.0931f, 17.0306f)
+                    curveTo(7.3215f, 17.8023f, 6.884f, 18.8463f, 6.875f, 19.9375f)
+                    verticalLineTo(20.625f)
+                    horizontalLineTo(15.125f)
+                    verticalLineTo(19.9375f)
+                    curveTo(15.116f, 18.8463f, 14.6785f, 17.8023f, 13.9069f, 17.0306f)
+                    curveTo(13.1352f, 16.259f, 12.0912f, 15.8215f, 11.0f, 15.8125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(17.875f, 5.5f)
+                    curveTo(19.0141f, 5.5f, 19.9375f, 4.5766f, 19.9375f, 3.4375f)
+                    curveTo(19.9375f, 2.2984f, 19.0141f, 1.375f, 17.875f, 1.375f)
+                    curveTo(16.7359f, 1.375f, 15.8125f, 2.2984f, 15.8125f, 3.4375f)
+                    curveTo(15.8125f, 4.5766f, 16.7359f, 5.5f, 17.875f, 5.5f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(21.3125f, 9.625f)
+                    curveTo(21.3125f, 7.0469f, 19.7656f, 5.5f, 17.875f, 5.5f)
+                    curveTo(15.9844f, 5.5f, 14.4375f, 7.0469f, 14.4375f, 9.625f)
+                    horizontalLineTo(21.3125f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(4.125f, 5.5f)
+                    curveTo(5.2641f, 5.5f, 6.1875f, 4.5766f, 6.1875f, 3.4375f)
+                    curveTo(6.1875f, 2.2984f, 5.2641f, 1.375f, 4.125f, 1.375f)
+                    curveTo(2.9859f, 1.375f, 2.0625f, 2.2984f, 2.0625f, 3.4375f)
+                    curveTo(2.0625f, 4.5766f, 2.9859f, 5.5f, 4.125f, 5.5f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(7.5625f, 9.625f)
+                    curveTo(7.5625f, 7.0469f, 6.0156f, 5.5f, 4.125f, 5.5f)
+                    curveTo(2.2344f, 5.5f, 0.6875f, 7.0469f, 0.6875f, 9.625f)
+                    horizontalLineTo(7.5625f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF241912)),
+                    strokeLineWidth = 1.2f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType =
+                    NonZero
+                ) {
+                    moveTo(4.125f, 11.6875f)
+                    lineTo(6.875f, 14.4375f)
+                    moveTo(17.875f, 11.6875f)
+                    lineTo(15.125f, 14.4375f)
+                    moveTo(8.25f, 4.8125f)
+                    horizontalLineTo(13.75f)
+                }
+            }
+        }
+            .build()
+        return _icBottomFollowLight!!
+    }
+
+private var _icBottomFollowLight: ImageVector? = null

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/MyPageScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/member/view/MyPageScreen.kt
@@ -45,7 +45,6 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Composable
 fun MyPageScreen(
     navigateToModifyProfile: () -> Unit,
-    navigateToFollowListScreen: () -> Unit,
     navigateToSettingScreen: () -> Unit
 ) {
     val myPageViewModel: MyPageViewModel = hiltViewModel()
@@ -79,7 +78,6 @@ fun MyPageScreen(
             followingCount = 4,
             followerCount = 2,
             onProfileClick = navigateToModifyProfile,
-            onFollowListClick = navigateToFollowListScreen
         )
 
         Spacer(modifier = Modifier.height(28.dp))
@@ -125,7 +123,6 @@ fun MyProfile(
     followingCount: Int,
     followerCount: Int,
     onProfileClick: () -> Unit,
-    onFollowListClick: () -> Unit
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -147,10 +144,7 @@ fun MyProfile(
                 style = PomoroDoTheme.typography.laundryGothicRegular20
             )
 
-            Row(
-                modifier = Modifier.clickableWithoutRipple { onFollowListClick() },
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 FollowText(title = stringResource(R.string.title_following), count = followingCount)
                 FollowText(title = stringResource(R.string.title_follower), count = followerCount)
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/setting/view/SettingScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.tico.pomorodo.BuildConfig
 import com.tico.pomorodo.R
-import com.tico.pomorodo.ui.common.view.CustomTopAppBarWithSingleButton
+import com.tico.pomorodo.ui.common.view.CustomTopAppBarWithNavigation
 import com.tico.pomorodo.ui.common.view.SimpleIcon
 import com.tico.pomorodo.ui.common.view.clickableWithRipple
 import com.tico.pomorodo.ui.theme.IC_ARROW_RIGHT
@@ -44,7 +44,7 @@ fun SettingScreen(
                 .padding(horizontal = 18.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            CustomTopAppBarWithSingleButton(
+            CustomTopAppBarWithNavigation(
                 title = stringResource(R.string.title_setting_screen),
                 navigationAction = { popBackStack() }
             )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/IconPackString.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/IconPackString.kt
@@ -2,6 +2,7 @@ package com.tico.pomorodo.ui.theme
 
 const val IC_BOTTOM_TIMER = "ic_bottom_timer"
 const val IC_BOTTOM_TODO = "ic_bottom_todo"
+const val IC_BOTTOM_FOLLOW = "ic_bottom_follow"
 const val IC_BOTTOM_MY_INFO = "ic_bottom_my_info"
 
 const val BG_CIRCULAR_TIMER = "bg_circular_timer"

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/__DarkIconPack.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/__DarkIconPack.kt
@@ -8,6 +8,7 @@ import com.tico.pomorodo.ui.iconpack.darkiconpack.IcAllCleanDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcArrowBackDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcArrowFrontDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcArrowRightDark
+import com.tico.pomorodo.ui.iconpack.darkiconpack.IcBottomFollowDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcBottomMyInfoDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcBottomTimerDark
 import com.tico.pomorodo.ui.iconpack.darkiconpack.IcBottomTodoDark
@@ -42,6 +43,7 @@ object DarkIconPack {
         mapOf(
             IC_BOTTOM_MY_INFO to IcBottomMyInfoDark,
             IC_BOTTOM_TODO to IcBottomTodoDark,
+            IC_BOTTOM_FOLLOW to IcBottomFollowDark,
             IC_BOTTOM_TIMER to IcBottomTimerDark,
             BG_CIRCULAR_TIMER to BgCircularTimerDark,
             IC_ARROW_FRONT to IcArrowFrontDark,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/__LightIconPack.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/theme/__LightIconPack.kt
@@ -8,6 +8,7 @@ import com.tico.pomorodo.ui.iconpack.lighticonpack.IcAllCleanLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcArrowBackLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcArrowFrontLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcArrowRightLight
+import com.tico.pomorodo.ui.iconpack.lighticonpack.IcBottomFollowLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcBottomMyInfoLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcBottomTimerLight
 import com.tico.pomorodo.ui.iconpack.lighticonpack.IcBottomTodoLight
@@ -42,6 +43,7 @@ object LightIconPack {
         mapOf(
             IC_BOTTOM_MY_INFO to IcBottomMyInfoLight,
             IC_BOTTOM_TODO to IcBottomTodoLight,
+            IC_BOTTOM_FOLLOW to IcBottomFollowLight,
             IC_BOTTOM_TIMER to IcBottomTimerLight,
             BG_CIRCULAR_TIMER to BgCircularTimerLight,
             IC_ARROW_FRONT to IcArrowFrontLight,

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     // bottom navigation bar
     <string name="title_timer">타이머</string>
     <string name="title_todo">할 일 목록</string>
+    <string name="title_follow">팔로우</string>
     <string name="title_my_info">내 정보</string>
 
     // todo list dialog
@@ -209,7 +210,6 @@
     <string name="format_hour_minute_second">%02d:%02d:%02d</string>
 
     // common - follow
-    <string name="title_follow">팔로우</string>
     <string name="content_unfollow">언팔로우</string>
     <string name="title_following">팔로잉</string>
     <string name="title_follower">팔로워</string>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -196,6 +196,9 @@
     <string name="content_app_theme_dark">다크</string>
     <string name="content_app_theme_system">시스템 설정</string>
 
+    // follow
+    <string name="content_ic_add_follower">팔로워 추가 버튼</string>
+
     // common
     <string name="content_next">다음</string>
     <string name="content_cancel">취소</string>


### PR DESCRIPTION
기존의 방식(마이페이지의 팔로워 정보에서 접근하던 방식)에서 새로운 방식(별도의 탭으로 구성)으로 변경
- 팔로워 탭 생성
- follow 패키지에 팔로워 화면 코드 이동
- CustomTopAppBarWithSingleButton를 CustomTopAppBarWithNavigation로 변경
- 마이페이지의 follow list 화면 연결 해제 및 코드 삭제