### PR TITLE
[SETTING] 서버 이전에 따른 swagger URL 주소 변경 (TICO-295)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/config/SwaggerConfig.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/config/SwaggerConfig.java
@@ -20,18 +20,20 @@ import org.springframework.context.annotation.Configuration;
                         + "이 API 문서는 Pomoro-Do! 서비스의 주요 기능을 설명합니다. <br>" // 서비스 설명
                         + "<br>"
                         + "API는 HTTPS 프로토콜을 통해 제공되며, 기본 URL은 https://pomorodo.shop/api 입니다. <br>" // API 사용 설명
+                        + "테스트 및 개발 환경에서는 http://13.209.240.41:8080/api URL을 사용할 수 있습니다. (도메인 미적용)<br>"
                         + "<br>"
                         + "모든 API 요청에는 JWT 인증이 필요하며, Authorization 헤더에 Bearer 토큰을 포함해야 합니다. <br>"
                         + "단, 회원가입, 로그인, 토큰 재발행 API는 인증이 필요하지 않습니다.", // JWT 인증 설명
                 version = "v1", // 서비스 버전
                 contact = @Contact(
                         name = "TICO", // 연락처 이름
-                        url = "https://pomorodo.shop/contact", // 연락처 URL
+//                        url = "https://pomorodo.shop/contact", // 연락처 URL
                         email = "tico240516@gmail.com" // 연락처 이메일
                 )
         ),
         servers = {
                 @Server(url = "/", description = "접속 서버 관계 없이 Swagger에서 테스트 가능"), // 전체 서버 설정
+                @Server(url = "http://13.209.240.41:8080", description = "<HTTP 서버> HTTP 서버에서 접속 시 Swagger에서 테스트 가능"), // HTTP 서버
                 @Server(url = "https://pomorodo.shop", description = "<HTTPS 서버> HTTPS 서버에서 접속 시 Swagger에서 테스트 가능"), // HTTPS 서버
                 @Server(url = "http://pomorodo.shop:8080", description = "<HTTP 서버> HTTP 서버에서 접속 시 Swagger에서 테스트 가능") // HTTP 서버
         }


### PR DESCRIPTION
서버 이전으로 인해 swagger config의 URL 주소를 새로운 서버에 맞게 수정

Resolves: TICO-328
Related to: TICO-209