### PR TITLE
[CHORE] 카테고리 room 로직 변경 (TICO-178) 

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/common/util/Converters.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/common/util/Converters.kt
@@ -1,9 +1,30 @@
 package com.tico.pomorodo.common.util
 
 import androidx.room.TypeConverter
+import com.tico.pomorodo.data.local.entity.UserEntity
 import kotlinx.datetime.LocalDate
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 class Converters {
+    @TypeConverter
+    fun userListToJson(value: List<UserEntity>?): String {
+        val json = Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+        return json.encodeToString(value)
+    }
+
+    @TypeConverter
+    fun jsonToUserList(value: String): List<UserEntity>? {
+        val json = Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+        return json.decodeFromString(value)
+    }
+
     @TypeConverter
     fun fromLocalDate(date: LocalDate): Int {
         return date.toEpochDays()

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/dao/CategoryDao.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/dao/CategoryDao.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface CategoryDao{
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAll(categories: List<CategoryEntity>)
+    suspend fun insertAll(categories: List<CategoryEntity>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(category: CategoryEntity)
@@ -29,5 +29,5 @@ interface CategoryDao{
     fun getAllCategory(): Flow<List<CategoryEntity>>
 
     @Query("SELECT * from category_table WHERE id = :id")
-    fun getCategory(id: Int): Flow<CategoryEntity>
+    fun getCategoryInfo(id: Int): Flow<CategoryEntity>
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
@@ -1,6 +1,10 @@
 package com.tico.pomorodo.data.local.datasource
 
+import com.tico.pomorodo.data.local.entity.CategoryEntity
+import com.tico.pomorodo.data.local.entity.UserEntity
+import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.InviteCategory
+import com.tico.pomorodo.data.model.OpenSettings
 import com.tico.pomorodo.data.model.User
 import com.tico.pomorodo.domain.model.Follow
 
@@ -49,5 +53,54 @@ object DataSource {
         Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
         Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
         Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+    )
+
+    val INITIAL_CATEGORY_DATA = listOf(
+        CategoryEntity(
+            id = 1,
+            type = CategoryType.GROUP,
+            openSettings = OpenSettings.GROUP,
+            title = "그룹 카테고리 1",
+            groupMemberCount = 2,
+            isGroupReader = true,
+            groupReader = "사용자 1",
+            groupMember = listOf(
+                UserEntity(id = 1, name = "사용자 1", email = "abc@abc.abc"),
+                UserEntity(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
+                UserEntity(id = 3, name = "사용자 3", email = "abce@abc.abc")
+            ),
+        ),
+        CategoryEntity(
+            id = 2,
+            type = CategoryType.GROUP,
+            openSettings = OpenSettings.GROUP,
+            title = "그룹 카테고리 2",
+            groupMemberCount = 2,
+            isGroupReader = false,
+            groupReader = "사용자 2",
+            groupMember = listOf(
+                UserEntity(id = 1, name = "사용자 1", email = "abc@abc.abc"),
+                UserEntity(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
+                UserEntity(id = 3, name = "사용자 3", email = "abce@abc.abc")
+            ),
+        ),
+        CategoryEntity(
+            id = 3,
+            type = CategoryType.GENERAL,
+            openSettings = OpenSettings.ME,
+            title = "일반 카테고리 1",
+            isGroupReader = true,
+            groupReader = "사용자 1",
+            groupMember = null
+        ),
+        CategoryEntity(
+            id = 4,
+            type = CategoryType.GENERAL,
+            openSettings = OpenSettings.FOLLOWER,
+            title = "일반 카테고리 2",
+            isGroupReader = true,
+            groupReader = "사용자 1",
+            groupMember = null
+        ),
     )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/PomorodoDatabase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/PomorodoDatabase.kt
@@ -1,8 +1,6 @@
 package com.tico.pomorodo.data.local.datasource
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.tico.pomorodo.common.util.Converters
@@ -10,30 +8,19 @@ import com.tico.pomorodo.data.local.dao.CategoryDao
 import com.tico.pomorodo.data.local.dao.TodoDao
 import com.tico.pomorodo.data.local.entity.CategoryEntity
 import com.tico.pomorodo.data.local.entity.TodoEntity
+import com.tico.pomorodo.data.local.entity.UserEntity
 
-@Database(entities = [TodoEntity::class, CategoryEntity::class], version = 1, exportSchema = false)
+@Database(
+    entities = [TodoEntity::class, CategoryEntity::class, UserEntity::class],
+    version = 1,
+    exportSchema = false
+)
 @TypeConverters(Converters::class)
 abstract class PomorodoDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao
     abstract fun categoryDao(): CategoryDao
 
     companion object {
-        @Volatile
-        private var INSTANCE: PomorodoDatabase? = null
-
-        fun getDatabase(context: Context): PomorodoDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    PomorodoDatabase::class.java,
-                    DATABASE_NAME
-                )
-                    .build()
-                INSTANCE = instance
-                instance
-            }
-        }
-
-        private const val DATABASE_NAME = "pomorodo_database"
+        const val DATABASE_NAME = "pomorodo_database"
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/category/CategoryLocalDataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/category/CategoryLocalDataSource.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface CategoryLocalDataSource {
     suspend fun getAllCategory(): Flow<List<CategoryEntity>>
 
-    suspend fun getCategory(id: Int): Flow<CategoryEntity>
+    suspend fun getCategoryInfo(categoryId: Int): Flow<CategoryEntity>
 
     suspend fun insert(entity: CategoryEntity)
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/category/CategoryLocalDataSourceImpl.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/category/CategoryLocalDataSourceImpl.kt
@@ -11,8 +11,8 @@ class CategoryLocalDataSourceImpl @Inject constructor(private val categoryDao: C
         return categoryDao.getAllCategory()
     }
 
-    override suspend fun getCategory(id: Int): Flow<CategoryEntity> {
-        return categoryDao.getCategory(id)
+    override suspend fun getCategoryInfo(categoryId: Int): Flow<CategoryEntity> {
+        return categoryDao.getCategoryInfo(categoryId)
     }
 
     override suspend fun insert(entity: CategoryEntity) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/entity/CategoryEntity.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/entity/CategoryEntity.kt
@@ -5,15 +5,30 @@ import androidx.room.PrimaryKey
 import com.tico.pomorodo.data.model.Category
 import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.OpenSettings
+import kotlinx.serialization.Serializable
 
 @Entity(tableName = "category_table")
+@Serializable
 data class CategoryEntity(
-    @PrimaryKey
-    val id: Int,
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
     val title: String,
     val type: CategoryType,
-    val openSettings: OpenSettings = OpenSettings.FULL
+    val openSettings: OpenSettings,
+    val groupReader: String?,
+    val isGroupReader: Boolean?,
+    val groupMemberCount: Int = 0,
+    val groupMember: List<UserEntity>?
 )
 
 fun CategoryEntity.toCategory() =
-    Category(id = id, title = title, type = type, openSettings = openSettings)
+    Category(
+        id = id,
+        title = title,
+        type = type,
+        openSettings = openSettings,
+        groupReader = groupReader,
+        isGroupReader = isGroupReader,
+        groupMemberCount = groupMemberCount,
+        groupMember = groupMember?.map { it.toUser() }
+    )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/entity/UserEntity.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/entity/UserEntity.kt
@@ -1,0 +1,18 @@
+package com.tico.pomorodo.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.tico.pomorodo.data.model.User
+import kotlinx.serialization.Serializable
+
+@Entity(tableName = "user_table")
+@Serializable
+data class UserEntity(
+    @PrimaryKey
+    val id: Int,
+    val name: String,
+    val email: String,
+    val profileUrl: String? = null
+)
+
+fun UserEntity.toUser() = User(id, email, name, profileUrl)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/Category.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/Category.kt
@@ -21,5 +21,9 @@ fun Category.toCategoryEntity() = CategoryEntity(
     id = id,
     title = title,
     type = type,
-    openSettings = openSettings
+    openSettings = openSettings,
+    groupReader = groupReader,
+    isGroupReader = isGroupReader,
+    groupMemberCount = groupMemberCount,
+    groupMember = groupMember?.map(User::toUserEntity)
 )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/User.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/model/User.kt
@@ -1,8 +1,12 @@
 package com.tico.pomorodo.data.model
 
+import com.tico.pomorodo.data.local.entity.UserEntity
+
 data class User(
     val id: Int,
     val email: String,
     val name: String,
     val profileUrl: String? = null
 )
+
+fun User.toUserEntity() = UserEntity(id, email, name, profileUrl)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/CategoryRepositoryImpl.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/CategoryRepositoryImpl.kt
@@ -3,8 +3,14 @@ package com.tico.pomorodo.data.repository
 import com.tico.pomorodo.common.util.NetworkHelper
 import com.tico.pomorodo.common.util.wrapToResource
 import com.tico.pomorodo.data.local.datasource.category.CategoryLocalDataSource
+import com.tico.pomorodo.data.local.entity.CategoryEntity
 import com.tico.pomorodo.data.local.entity.toCategory
 import com.tico.pomorodo.data.model.Category
+import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.OpenSettings
+import com.tico.pomorodo.data.model.User
+import com.tico.pomorodo.data.model.toCategoryEntity
+import com.tico.pomorodo.data.model.toUserEntity
 import com.tico.pomorodo.domain.model.Resource
 import com.tico.pomorodo.domain.repository.CategoryRepository
 import kotlinx.coroutines.Dispatchers
@@ -33,23 +39,63 @@ class CategoryRepositoryImpl @Inject constructor(
         }
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun getCategory(id: Int): Flow<Resource<Category>> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCategoryInfo(categoryId: Int): Flow<Resource<Category>> = flow {
+        emit(Resource.Loading)
 
-    override suspend fun insert(entity: Category) {
-        TODO("Not yet implemented")
+        if (networkHelper.isNetworkConnected()) {
+            // TODO:bring network data
+        } else {
+            val data = categoryLocalDataSource.getCategoryInfo(categoryId).map {
+                wrapToResource(Dispatchers.IO) {
+                    it.toCategory()
+                }
+            }
+            emitAll(data)
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun insert(
+        title: String,
+        type: CategoryType,
+        isGroupReader: Boolean,
+        openSettings: OpenSettings,
+        groupReader: String,
+        groupMemberCount: Int,
+        groupMember: List<User>
+    ) {
+        val categoryEntity = CategoryEntity(
+            title = title,
+            type = type,
+            isGroupReader = isGroupReader,
+            openSettings = openSettings,
+            groupReader = groupReader,
+            groupMemberCount = groupMemberCount,
+            groupMember = groupMember.map(User::toUserEntity)
+        )
+        if (networkHelper.isNetworkConnected()) {
+
+        } else {
+            categoryLocalDataSource.insert(categoryEntity)
+        }
     }
 
     override suspend fun insertAll(entities: List<Category>) {
         TODO("Not yet implemented")
     }
 
-    override suspend fun update(entity: Category) {
-        TODO("Not yet implemented")
+    override suspend fun updateCategoryInfo(entity: Category) {
+        if (networkHelper.isNetworkConnected()) {
+
+        } else {
+            categoryLocalDataSource.update(entity.toCategoryEntity())
+        }
     }
 
-    override suspend fun delete(id: Int) {
-        TODO("Not yet implemented")
+    override suspend fun deleteCategoryInfo(id: Int) {
+        if (networkHelper.isNetworkConnected()) {
+
+        } else {
+            categoryLocalDataSource.delete(id)
+        }
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/DatabaseModule.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/DatabaseModule.kt
@@ -1,10 +1,11 @@
 package com.tico.pomorodo.di
 
 import android.content.Context
-import com.tico.pomorodo.common.util.NetworkHelper
+import androidx.room.Room
 import com.tico.pomorodo.data.local.dao.CategoryDao
 import com.tico.pomorodo.data.local.dao.TodoDao
 import com.tico.pomorodo.data.local.datasource.PomorodoDatabase
+import com.tico.pomorodo.data.local.datasource.PomorodoDatabase.Companion.DATABASE_NAME
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,7 +20,11 @@ object DatabaseModule {
     @Provides
     fun provideAppDatabase(
         @ApplicationContext context: Context
-    ): PomorodoDatabase = PomorodoDatabase.getDatabase(context)
+    ): PomorodoDatabase = Room.databaseBuilder(
+        context.applicationContext,
+        PomorodoDatabase::class.java,
+        DATABASE_NAME
+    ).build()
 
     @Singleton
     @Provides

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
@@ -7,10 +7,7 @@ import com.tico.pomorodo.domain.repository.TokenRepository
 import com.tico.pomorodo.domain.usecase.auth.ClearAccessTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.ClearIdTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.GetAccessTokenUseCase
-import com.tico.pomorodo.domain.usecase.category.GetAllCategoryUseCase
-import com.tico.pomorodo.domain.usecase.todo.GetAllTodoUseCase
 import com.tico.pomorodo.domain.usecase.auth.GetIdTokenUseCase
-import com.tico.pomorodo.domain.usecase.todo.InsertTodoUseCase
 import com.tico.pomorodo.domain.usecase.auth.IsAccessTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.JoinUseCase
 import com.tico.pomorodo.domain.usecase.auth.LoginUseCase
@@ -19,6 +16,11 @@ import com.tico.pomorodo.domain.usecase.auth.SaveAccessTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.SaveIdTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.SaveRefreshTokenUseCase
 import com.tico.pomorodo.domain.usecase.auth.ValidateTokenUseCase
+import com.tico.pomorodo.domain.usecase.category.GetAllCategoryUseCase
+import com.tico.pomorodo.domain.usecase.category.GetCategoryInfoUseCase
+import com.tico.pomorodo.domain.usecase.category.InsertCategoryUseCase
+import com.tico.pomorodo.domain.usecase.todo.GetAllTodoUseCase
+import com.tico.pomorodo.domain.usecase.todo.InsertTodoUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -116,5 +118,17 @@ object UseCaseModule {
     @Provides
     fun provideGetAllCategoryUseCase(categoryRepository: CategoryRepository): GetAllCategoryUseCase {
         return GetAllCategoryUseCase(categoryRepository)
+    }
+
+    @Singleton
+    @Provides
+    fun provideGetCategoryInfoUseCase(categoryRepository: CategoryRepository): GetCategoryInfoUseCase {
+        return GetCategoryInfoUseCase(categoryRepository)
+    }
+
+    @Singleton
+    @Provides
+    fun provideInsertCategoryUseCase(categoryRepository: CategoryRepository): InsertCategoryUseCase {
+        return InsertCategoryUseCase(categoryRepository)
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/CategoryRepository.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/CategoryRepository.kt
@@ -1,19 +1,30 @@
 package com.tico.pomorodo.domain.repository
 
 import com.tico.pomorodo.data.model.Category
+import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.OpenSettings
+import com.tico.pomorodo.data.model.User
 import com.tico.pomorodo.domain.model.Resource
 import kotlinx.coroutines.flow.Flow
 
 interface CategoryRepository {
     suspend fun getAllCategory(): Flow<Resource<List<Category>>>
 
-    suspend fun getCategory(id: Int): Flow<Resource<Category>>
+    suspend fun getCategoryInfo(categoryId: Int): Flow<Resource<Category>>
 
-    suspend fun insert(entity: Category)
+    suspend fun insert(
+        title: String,
+        type: CategoryType,
+        isGroupReader: Boolean,
+        openSettings: OpenSettings,
+        groupReader: String,
+        groupMemberCount: Int,
+        groupMember: List<User>
+    )
 
     suspend fun insertAll(entities: List<Category>)
 
-    suspend fun update(entity: Category)
+    suspend fun updateCategoryInfo(entity: Category)
 
-    suspend fun delete(id: Int)
+    suspend fun deleteCategoryInfo(id: Int)
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/GetCategoryInfoUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/GetCategoryInfoUseCase.kt
@@ -1,0 +1,12 @@
+package com.tico.pomorodo.domain.usecase.category
+
+import com.tico.pomorodo.domain.repository.CategoryRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetCategoryInfoUseCase @Inject constructor(private val categoryRepository: CategoryRepository) {
+    suspend operator fun invoke(categoryId: Int) = withContext(Dispatchers.IO) {
+        categoryRepository.getCategoryInfo(categoryId)
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/InsertCategoryUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/InsertCategoryUseCase.kt
@@ -1,0 +1,31 @@
+package com.tico.pomorodo.domain.usecase.category
+
+import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.OpenSettings
+import com.tico.pomorodo.data.model.User
+import com.tico.pomorodo.domain.repository.CategoryRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class InsertCategoryUseCase @Inject constructor(private val categoryRepository: CategoryRepository) {
+    suspend operator fun invoke(
+        title: String,
+        type: CategoryType,
+        isGroupReader: Boolean,
+        openSettings: OpenSettings,
+        groupReader: String,
+        groupMemberCount: Int,
+        groupMember: List<User>
+    ) = withContext(Dispatchers.IO) {
+        categoryRepository.insert(
+            title = title,
+            type = type,
+            isGroupReader = isGroupReader,
+            openSettings = openSettings,
+            groupReader = groupReader,
+            groupMemberCount = groupMemberCount,
+            groupMember = groupMember
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/UpdateCategoryInfoUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/category/UpdateCategoryInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.tico.pomorodo.domain.usecase.category
+
+import com.tico.pomorodo.data.model.Category
+import com.tico.pomorodo.domain.repository.CategoryRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class UpdateCategoryInfoUseCase @Inject constructor(private val categoryRepository: CategoryRepository) {
+    suspend operator fun invoke(category: Category) = withContext(Dispatchers.IO) {
+        categoryRepository.updateCategoryInfo(category)
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryAddViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryAddViewModel.kt
@@ -1,17 +1,22 @@
 package com.tico.pomorodo.ui.category.viewModel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.OpenSettings
 import com.tico.pomorodo.data.model.SelectedUser
+import com.tico.pomorodo.data.model.toUser
+import com.tico.pomorodo.domain.usecase.category.InsertCategoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CategoryAddViewModel @Inject constructor() : ViewModel() {
+class CategoryAddViewModel @Inject constructor(private val insertCategoryUseCase: InsertCategoryUseCase) :
+    ViewModel() {
 
     private var _title = MutableStateFlow("")
     val title: StateFlow<String>
@@ -57,7 +62,16 @@ class CategoryAddViewModel @Inject constructor() : ViewModel() {
         // TODO: 선택된 그룹원 불러오는 로직
     }
 
-    fun insertCategory() {
-        // TODO: insert category
+    fun insertCategory() = viewModelScope.launch {
+        val groupMember = selectedGroupMembers.value.filter { it.selected }.map { it.toUser() }
+        insertCategoryUseCase.invoke(
+            title = title.value,
+            type = type.value,
+            isGroupReader = true,
+            openSettings = openSettingOption.value,
+            groupReader = "",
+            groupMemberCount = groupMember.size,
+            groupMember = groupMember
+        )
     }
 }


### PR DESCRIPTION
**추가 사항**

- 카테고리의 그룹원을 저장하기 위한 UserEntity 추가
- 카테고리 entity와 mapper 확장 함수 변경
- Converter 추가
  - 그룹원을 저장하기 위한 user 목록을 json으로, json을 user 목록으로 전환하는 TypeConverter 추가
- user를 userEntity로 변환하는 mapper 확장함수 추가
- room DB에 초기 데이터 설정하는 로직 추가
- 카테고리 정보, 추가, 수정 UseCase 추가
- 카테고리 정보, 추가, 수정 UseCase 연결

**수정 사항**

- RoomDatabase 초기화 로직 리팩토링
  - PomorodoDatabase에서 Singleton 관리 로직 제거
      - @ Volatile 및 getDatabase 함수 삭제
      - DATABASE_NAME을 companion object에서 상수로 변경
  - DatabaseModule에서 RoomDatabase 빌더 직접 사용하도록 수정
      - PomorodoDatabase.getDatabase 함수 호출 제거
- category를 Entity로 전환하는 확장 함수 수정
- category 로직 변경
  - localDataSource, Repository, Dao의 매개변수 또는 이름 변경


Resolves: TICO-178
Related to: TICO-173