### PR TITLE
[FEAT] 인증 로직 userId 기반으로 통합 (TICO-382)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController {
      *
      * @param googleIdToken Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
-     * @return 성공 시 JWT 토큰 정보가 담긴 SuccessResponseDTO 반환
+     * @return 성공 시 JWT 토큰 정보가 담긴 SuccessResponse 반환
      * @throws CustomException 구글 ID 토큰 검증 실패 시 CustomException 발생
      */
     @Operation(
@@ -106,7 +106,7 @@ public class AuthController {
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
      * @param nickname 닉네임
      * @param profileImage 프로필 이미지
-     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
+     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse
      * @throws CustomException 구글 ID 토큰 검증에 실패한 경우 예외를 던집니다.
      */
     @Operation(
@@ -176,7 +176,7 @@ public class AuthController {
      *
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
      * @param refreshToken Refresh-Token 헤더에 포함된 리프레시 토큰
-     * @return 재발급된 JWT 토큰 정보가 담긴 SuccessResponseDTO 반환
+     * @return 재발급된 JWT 토큰 정보가 담긴 SuccessResponse 반환
      * @throws CustomException 리프레시 토큰 검증 실패 시 CustomException 발생
      */
     @Operation(
@@ -223,12 +223,11 @@ public class AuthController {
 
     /**
      * 로그아웃 API
-     *
      * 사용자가 로그아웃 시, 서버의 리프레시 토큰을 삭제합니다.
      *
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
      * @param refreshHeader Refresh-Token 헤더에 포함된 리프레시 토큰
-     * @return 로그아웃 성공 메시지를 담은 SuccessResponseDTO 반환
+     * @return 로그아웃 성공 메시지를 담은 SuccessResponse 반환
      * @throws CustomException 리프레시 토큰 삭제 실패 시 CustomException 발생
      */
     @Operation(
@@ -260,7 +259,7 @@ public class AuthController {
             @RequestHeader("Refresh-Token") String refreshHeader
     ) {
         // 토큰 검증
-        tokenService.validateRefreshTokenDetails(refreshHeader, deviceId, customUserDetails.getUsername());
+        tokenService.validateRefreshTokenDetails(refreshHeader, deviceId, customUserDetails.getUserId());
         // 토큰 삭제 (액세스 토큰으로 현재 Redis 정보 삭제)
         tokenService.deleteRefreshTokenByDeviceId(deviceId);
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
@@ -9,7 +9,7 @@ import com.tico.pomoro_do.global.code.SuccessCode;
 import com.tico.pomoro_do.global.enums.ProfileImageType;
 import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.exception.CustomException;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -78,7 +78,7 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "등록되지 않은 사용자 (code: U-104)")
     })
     @PostMapping("/google/login")
-    public ResponseEntity<SuccessResponseDTO<TokenResponse>> googleLogin(
+    public ResponseEntity<SuccessResponse<TokenResponse>> googleLogin(
             @RequestHeader("Google-ID-Token") String googleIdToken,
             @RequestHeader("Device-ID") String deviceId
     ) {
@@ -87,7 +87,7 @@ public class AuthController {
             TokenResponse jwtResponse = authService.googleLogin(googleIdToken, deviceId);
 
             // 성공 응답 생성
-            SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
+            SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                     .status(SuccessCode.GOOGLE_LOGIN_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_LOGIN_SUCCESS.getMessage())
                     .data(jwtResponse)
@@ -150,7 +150,7 @@ public class AuthController {
             @ApiResponse(responseCode = "409", description = "이미 등록된 사용자 (code: U-105)")
     })
     @PostMapping(value = "/google/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponseDTO<TokenResponse>> googleJoin(
+    public ResponseEntity<SuccessResponse<TokenResponse>> googleJoin(
             @RequestHeader("Google-ID-Token") String googleIdTokenHeader,
             @RequestHeader("Device-ID") String deviceId,
             @RequestParam("nickname") String nickname,
@@ -159,7 +159,7 @@ public class AuthController {
     ) {
         try {
             TokenResponse jwtResponse = authService.googleJoin(googleIdTokenHeader, deviceId, nickname, profileImage, imageType);
-            SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
+            SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                     .status(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getMessage())
                     .data(jwtResponse)
@@ -204,14 +204,14 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "기기 ID 또는 리프레시 토큰이 DB에 존재하지 않음"),
     })
     @PostMapping("/tokens/reissue")
-    public ResponseEntity<SuccessResponseDTO<TokenResponse>> reissueToken(
+    public ResponseEntity<SuccessResponse<TokenResponse>> reissueToken(
             @RequestHeader("Device-ID") String deviceId,
             @RequestHeader("Refresh-Token") String refreshToken
     ) {
         // AuthService의 reissueToken 메서드 호출하여 결과 받기
         TokenResponse tokenResponse = authService.reissueToken(deviceId, refreshToken);
 
-        SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
+        SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                 .status(SuccessCode.ACCESS_TOKEN_REISSUED.getHttpStatus().value())
                 .message(SuccessCode.ACCESS_TOKEN_REISSUED.getMessage())
                 .data(tokenResponse)
@@ -253,7 +253,7 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @DeleteMapping("/logout")
-    public ResponseEntity<SuccessResponseDTO<String>> removeToken(
+    public ResponseEntity<SuccessResponse<String>> removeToken(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestHeader("Device-ID") String deviceId,
             @RequestHeader("Refresh-Token") String refreshHeader
@@ -263,7 +263,7 @@ public class AuthController {
         // 토큰 삭제 (액세스 토큰으로 현재 Redis 정보 삭제)
         tokenService.deleteRefreshTokenByDeviceId(deviceId);
 
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.LOGOUT_SUCCESS.getMessage())
                 .data(SuccessCode.LOGOUT_SUCCESS.name()) // data가 없을 때는 null로 설정
@@ -295,12 +295,12 @@ public class AuthController {
             @ApiResponse(responseCode = "401", description = "토큰이 유효하지 않음")
     })
     @PostMapping("/tokens/validation")
-    public ResponseEntity<SuccessResponseDTO<String>> validateToken(HttpServletRequest request, @RequestParam("tokenType") TokenType tokenType) {
+    public ResponseEntity<SuccessResponse<String>> validateToken(HttpServletRequest request, @RequestParam("tokenType") TokenType tokenType) {
 
         String tokenHeader = request.getHeader("Authorization");
         // 토큰 검증 후 SuccessCode 반환
         SuccessCode successCode = tokenService.validateTokenAndGetSuccessCode(tokenHeader, tokenType);;
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(successCode.getHttpStatus().value())
                 .message(successCode.getMessage())
                 .data(successCode.name()) // data가 없을 때는 null로 설정

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/dto/AuthUser.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/dto/AuthUser.java
@@ -5,16 +5,18 @@ import lombok.Getter;
 
 /**
  * 인증(Authentication) 과정에서 사용자 정보를 담는 내부 객체.
- * JWT에서 추출된 사용자 정보 (email, role)를 포함하며,
+ * JWT에서 추출된 사용자 정보 (userId, email, role)를 포함하며,
  * CustomUserDetails에서 사용됩니다.
  */
 @Getter
 public class AuthUser {
+    private Long userId;
     private String email;
     private String role;
 
     @Builder
-    public AuthUser(String email, String role){
+    public AuthUser(Long userId, String email, String role){
+        this.userId = userId;
         this.email = email;
         this.role = role;
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/entity/RefreshToken.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/entity/RefreshToken.java
@@ -19,8 +19,8 @@ public class RefreshToken {
     @Column(name = "token_id")
     private Long id;
 
-    @Column(name = "email", nullable = false) // username → email
-    private String email;
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
 
     @Column(name = "refresh_token", nullable = false)
     private String refreshToken;
@@ -32,8 +32,8 @@ public class RefreshToken {
     private LocalDateTime expiresAt;
 
     @Builder
-    public RefreshToken(String email, String refreshToken, String deviceId, LocalDateTime expiresAt) {
-        this.email = email;
+    public RefreshToken(Long userId, String refreshToken, String deviceId, LocalDateTime expiresAt) {
+        this.userId = userId;
         this.refreshToken = refreshToken;
         this.deviceId = deviceId;
         this.expiresAt = expiresAt;

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/repository/RefreshTokenRepository.java
@@ -14,8 +14,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     // 해당 리프레쉬 토큰을 삭제하는 메소드
     void deleteByRefreshToken(String refreshToken);
 
-    // 사용자 이름을 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
-    void deleteByEmail(String email);
+    // 사용자 ID를 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
+    void deleteByUserId(Long userId);
 
     // 디바이스 id를 기준으로 모든 리프레쉬 토큰을 삭제하는 메소드
     void deleteByDeviceId(String deviceId);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/security/CustomUserDetails.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/security/CustomUserDetails.java
@@ -18,6 +18,18 @@ public class CustomUserDetails implements UserDetails {
 
     private final AuthUser authUser;
 
+    // Spring Security가 내부적으로 사용하는 사용자 식별자
+    @Override
+    public String getUsername() {
+//        return String.valueOf(authUser.getUserId());
+        return authUser.getEmail();     // username은 email로 대체
+    }
+
+    // 실제 비즈니스 로직에서 사용할 userId 반환
+    public Long getUserId() {
+        return authUser.getUserId();
+    }
+
     // 사용자 권한 반환 -> role 가져오기
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -37,7 +49,7 @@ public class CustomUserDetails implements UserDetails {
         return collection;
     }
 
-    // 비밀번호는 JWT 인증 방식에서는 사용되지 않으므로 null 반환
+    // 소셜 로그인이므로 패스워드 사용하지 않음
     @Override
     public String getPassword() {
 
@@ -45,35 +57,28 @@ public class CustomUserDetails implements UserDetails {
         return null;
     }
 
-    // 사용자 고유 식별자(username)로 email을 반환
-    @Override
-    public String getUsername() {
-
-        return authUser.getEmail();     // username은 email로 대체됨
-    }
-
-    // 계정이 만료되지 않았는지 확인 (항상 true)
+    // 계정 만료 여부
     @Override
     public boolean isAccountNonExpired() {
 
         return true;
     }
 
-    // 계정이 잠겨있지 않은지 확인 (항상 true)
+    // 계정 잠금 여부
     @Override
     public boolean isAccountNonLocked() {
 
         return true;
     }
 
-    // 비밀번호가 만료되지 않았는지 확인 (항상 true)
+    // 자격 증명 만료 여부
     @Override
     public boolean isCredentialsNonExpired() {
 
         return true;
     }
 
-    // 계정이 활성화되어 있는지 확인 (항상 true)
+    // 계정 활성화 여부
     @Override
     public boolean isEnabled() {
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthService.java
@@ -18,7 +18,7 @@ public interface AuthService {
      * 구글 ID 토큰으로 무결성 검증
      *
      * @param idToken 구글 ID 토큰
-     * @return 검증된 GoogleUserInfoDTO
+     * @return 검증된 GoogleUserInfo
      * @throws GeneralSecurityException 구글 ID 토큰 검증 중 발생하는 보안 예외
      * @throws IOException IO 예외
      * @throws CustomException 구글 ID 토큰이 유효하지 않은 경우 예외
@@ -30,7 +30,7 @@ public interface AuthService {
      *
      * @param idTokenHeader Google-ID-Token 헤더에 포함된 구글 ID 토큰
      * @param deviceId Device-ID 헤더에 포함된 기기 고유 번호
-     * @return TokenDTO를 포함하는 객체
+     * @return TokenResponse를 포함하는 객체
      * @throws GeneralSecurityException 구글 ID 토큰 검증 중 발생하는 보안 예외
      * @throws IOException IO 예외
      * @throws CustomException 구글 ID 토큰이 유효하지 않거나 등록되지 않은 사용자인 경우 예외
@@ -45,7 +45,7 @@ public interface AuthService {
      * @param nickname 닉네임
      * @param profileImage 프로필 이미지
      * @param imageType 프로필 이미지 타입
-     * @return TokenDTO를 포함하는 객체
+     * @return TokenResponse를 포함하는 객체
      * @throws GeneralSecurityException 구글 ID 토큰 검증 중 발생하는 보안 예외
      * @throws IOException IO 예외
      * @throws CustomException 구글 ID 토큰이 유효하지 않거나 이미 등록된 사용자인 경우 예외
@@ -55,20 +55,20 @@ public interface AuthService {
     /**
      * 새 사용자 생성
      *
-     * @param username 사용자 이메일
+     * @param email 사용자 이메일
      * @param nickname 사용자 닉네임
      * @param profileImageUrl 사용자 프로필 이미지 URL
      * @param role 사용자 역할
      * @return 생성된 User 객체
      */
-    User createUser(String username, String nickname, String profileImageUrl, UserRole role);
+    User createUser(String email, String nickname, String profileImageUrl, UserRole role);
 
     /**
      * Refresh 토큰을 사용하여 Access 토큰 재발급
      *
      * @param deviceId 기기 고유 번호
      * @param refreshHeader 리프레시 토큰
-     * @return 새 Access 토큰을 포함하는 TokenDTO
+     * @return 새 Access 토큰을 포함하는 TokenResponse
      */
     TokenResponse reissueToken(String deviceId, String refreshHeader);
 

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
@@ -86,11 +86,12 @@ public class AuthServiceImpl implements AuthService {
         // 토큰 추출
         String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         // 구글 토큰 유효성 검증
-        GoogleUserInfo userInfo = verifyGoogleIdToken(idToken);
+        GoogleUserInfo googleUserInfo = verifyGoogleIdToken(idToken);
         // 회원 가입 여부 판단 -> 회원 가입 x -> 에러 발생
-        userService.validateEmailExists(userInfo.getEmail());
+//        userService.validateEmailExists(userInfo.getEmail());
+        User user = userService.findByEmail(googleUserInfo.getEmail());
         // 회원 가입되어 있으면 토큰 발급
-        return tokenService.createAuthTokens(userInfo.getEmail(), String.valueOf(UserRole.USER), deviceId);
+        return tokenService.createAuthTokens(user.getId(), user.getEmail(), String.valueOf(UserRole.USER), deviceId);
     }
 
     // 구글 회원가입
@@ -104,16 +105,16 @@ public class AuthServiceImpl implements AuthService {
         // 구글 idToken 유효성 검사 및 추출
         String idToken = jwtUtil.extractToken(idTokenHeader, TokenType.GOOGLE);
         // 구글 id 토큰 검증
-        GoogleUserInfo userInfo = verifyGoogleIdToken(idToken);
+        GoogleUserInfo googleUserInfo = verifyGoogleIdToken(idToken);
         // 사용자의 이메일 중복 체크
-        userService.isEmailRegistered(userInfo.getEmail());
+        userService.isEmailRegistered(googleUserInfo.getEmail());
 
         // 알맞는 profileImage url 가져오기 (null 가능)
-        String profileImageUrl = determineProfileImageUrl(imageType, profileImage, userInfo);
+        String profileImageUrl = determineProfileImageUrl(imageType, profileImage, googleUserInfo);
         // 사용자 정보 저장
-        User user = createUser(userInfo.getEmail(), nickname, profileImageUrl, UserRole.USER);
+        User user = createUser(googleUserInfo.getEmail(), nickname, profileImageUrl, UserRole.USER);
         // 소셜 로그인 정보 저장
-        createSocialLogin(user, userInfo.getUserId());
+        createSocialLogin(user, googleUserInfo.getUserId());
 
         // 기본 카테고리 생성
         Category category = categoryService.createNewCategory(
@@ -125,8 +126,8 @@ public class AuthServiceImpl implements AuthService {
                 CategoryConstants.DEFAULT_CATEGORY_TYPE
         );
 
-        log.info("구글 회원가입 성공: 이메일 = {}", userInfo.getEmail());
-        return tokenService.createAuthTokens(userInfo.getEmail(), String.valueOf(UserRole.USER), deviceId);
+        log.info("구글 회원가입 성공: 이메일 = {}", googleUserInfo.getEmail());
+        return tokenService.createAuthTokens(user.getId(), user.getEmail(), String.valueOf(UserRole.USER), deviceId);
     }
 
     /**
@@ -203,10 +204,11 @@ public class AuthServiceImpl implements AuthService {
 
         // 생성 로직
         // 리프레시 토큰에서 사용자 정보를 추출합니다.
+        Long userId = jwtUtil.getUserId(refresh);
         String email = jwtUtil.getEmail(refresh);
         String role = jwtUtil.getRole(refresh);
         // 토큰 재발행
-        return tokenService.createAuthTokens(email, role, deviceId);
+        return tokenService.createAuthTokens(userId, email, role, deviceId);
 
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
@@ -146,15 +146,15 @@ public class AuthServiceImpl implements AuthService {
      *
      * @param imageType 프로필 이미지의 유형 (FILE, GOOGLE, 또는 DEFAULT)
      * @param profileImage 사용자가 업로드한 프로필 이미지 파일 (FILE 유형일 때 사용)
-     * @param userInfo 구글 사용자 정보 DTO (GOOGLE 유형일 때 사용)
+     * @param googleUserInfo 구글 사용자 정보 DTO (GOOGLE 유형일 때 사용)
      * @return 프로필 이미지의 URL. FILE 유형인 경우 업로드된 이미지의 URL을,
      *         GOOGLE 유형인 경우 구글 프로필 이미지 URL을 반환하며,
      *         DEFAULT 유형인 경우 null을 반환합니다.
      */
-    private String determineProfileImageUrl(ProfileImageType imageType, MultipartFile profileImage, GoogleUserInfo userInfo) {
+    private String determineProfileImageUrl(ProfileImageType imageType, MultipartFile profileImage, GoogleUserInfo googleUserInfo) {
         return switch (imageType) {
             case FILE -> imageService.imageUpload(profileImage, S3Folder.PROFILES.getFolderName());
-            case GOOGLE -> userInfo.getPictureUrl();
+            case GOOGLE -> googleUserInfo.getPictureUrl();
             // DEFAULT 타입일 때 default로 통합하여 처리
             default -> null;
         };

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/AuthServiceImpl.java
@@ -89,7 +89,7 @@ public class AuthServiceImpl implements AuthService {
         GoogleUserInfo googleUserInfo = verifyGoogleIdToken(idToken);
         // 회원 가입 여부 판단 -> 회원 가입 x -> 에러 발생
 //        userService.validateEmailExists(userInfo.getEmail());
-        User user = userService.findByEmail(googleUserInfo.getEmail());
+        User user = userService.findUserByEmail(googleUserInfo.getEmail());
         // 회원 가입되어 있으면 토큰 발급
         return tokenService.createAuthTokens(user.getId(), user.getEmail(), String.valueOf(UserRole.USER), deviceId);
     }
@@ -107,7 +107,7 @@ public class AuthServiceImpl implements AuthService {
         // 구글 id 토큰 검증
         GoogleUserInfo googleUserInfo = verifyGoogleIdToken(idToken);
         // 사용자의 이메일 중복 체크
-        userService.isEmailRegistered(googleUserInfo.getEmail());
+        userService.verifyEmailNotRegistered(googleUserInfo.getEmail());
 
         // 알맞는 profileImage url 가져오기 (null 가능)
         String profileImageUrl = determineProfileImageUrl(imageType, profileImage, googleUserInfo);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/CustomUserDetailsService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/CustomUserDetailsService.java
@@ -34,6 +34,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (userData.isPresent()) {
             User user = userData.get();
             AuthUser authUser = AuthUser.builder()
+                    .userId(user.getId())
                     .email(user.getEmail())
                     .role(String.valueOf(user.getRole()))
                     .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenService.java
@@ -12,12 +12,13 @@ public interface TokenService {
     /**
      * 사용자 인증을 위한 액세스 토큰과 리프레시 토큰을 생성하고 저장
      *
+     * @param userId 사용자 ID
      * @param email 사용자 이메일
      * @param role 사용자 역할
      * @param deviceId 기기 고유 번호
      * @return TokenDTO 객체, 생성된 액세스 토큰을 포함
      */
-    TokenResponse createAuthTokens(String email, String role, String deviceId);
+    TokenResponse createAuthTokens(Long userId, String email, String role, String deviceId);
 
     /**
      * 새로운 리프레시 토큰을 저장합니다.

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenService.java
@@ -23,12 +23,12 @@ public interface TokenService {
     /**
      * 새로운 리프레시 토큰을 저장합니다.
      *
-     * @param email 사용자 이메일
+     * @param userId 사용자 ID
      * @param refresh 새로운 리프레시 토큰
      * @param expiredMs 토큰 만료 시간 (밀리초 단위)
      * @param deviceId 기기 고유 번호
      */
-    void createRefreshToken(String email, String refresh, Long expiredMs, String deviceId);
+    void createRefreshToken(Long userId, String refresh, Long expiredMs, String deviceId);
 
     // 토큰 엔티티 가져오기
     /**
@@ -53,9 +53,15 @@ public interface TokenService {
      *
      * @param refreshHeader 리프레시 토큰 헤더
      * @param deviceId 기기 고유 번호
-     * @param email 사용자 이메일
+     * @param userId 사용자 ID
      */
-    void validateRefreshTokenDetails(String refreshHeader, String deviceId, String email);
+    void validateRefreshTokenDetails(String refreshHeader, String deviceId, Long userId);
+    /**
+     * 리프레시 토큰을 검증하고, 토큰을 반환합니다.
+     *
+     * @param refreshHeader 리프레시 토큰 헤더
+     * @param deviceId 기기 고유 번호
+     */
     String validateAndGetRefreshToken(String refreshHeader, String deviceId);
 
 
@@ -70,9 +76,9 @@ public interface TokenService {
     /**
      * 회원탈퇴 시 회원의 모든 리프레시 토큰 삭제
      *
-     * @param email 사용자 이메일
+     * @param userId 사용자 ID
      */
-    void deleteAllRefreshTokensByEmail(String email);
+    void deleteAllRefreshTokensByUserId(Long userId);
 
     /**
      * 주어진 토큰을 검증하고 토큰 타입에 대한 SuccessCode 반환

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/service/TokenServiceImpl.java
@@ -34,11 +34,11 @@ public class TokenServiceImpl implements TokenService {
 
     // 토큰 생성 및 저장
     @Override
-    public TokenResponse createAuthTokens(String email, String role, String deviceId) {
+    public TokenResponse createAuthTokens(Long userId, String email, String role, String deviceId) {
         // 액세스 토큰 생성
-        String accessToken = jwtUtil.createJwt(TokenType.ACCESS.name(), email, role, accessExpiration); // 60분
+        String accessToken = jwtUtil.createJwt(TokenType.ACCESS.name(), userId, email, role, accessExpiration); // 60분
         // 리프레시 토큰 생성
-        String refreshToken = jwtUtil.createJwt(TokenType.REFRESH.name(), email, role, refreshExpiration); // 24시간
+        String refreshToken = jwtUtil.createJwt(TokenType.REFRESH.name(), userId, email, role, refreshExpiration); // 24시간
 
         // DB에서 deviceId에 해당하는 기존 리프레시 토큰을 삭제
         deleteRefreshTokenByDeviceId(deviceId);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
@@ -7,7 +7,7 @@ import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.domain.user.service.UserService;
 import com.tico.pomoro_do.domain.auth.security.CustomUserDetails;
 import com.tico.pomoro_do.global.code.SuccessCode;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -55,14 +55,14 @@ public class CategoryController {
             @ApiResponse(responseCode = "500", description = "서버 오류 - 서버에서 예기치 않은 오류 발생")
     })
     @PostMapping
-    public ResponseEntity<SuccessResponseDTO<String>> createCategory(
+    public ResponseEntity<SuccessResponse<String>> createCategory(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody CategoryCreationDTO request
     ){
         String email = customUserDetails.getUsername();
         categoryService.createCategory(email, request);
 
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(SuccessCode.CATEGORY_CREATION_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_CREATION_SUCCESS.getMessage())
                 .data(SuccessCode.CATEGORY_CREATION_SUCCESS.name())
@@ -79,13 +79,13 @@ public class CategoryController {
                     "일반 / 그룹 / 초대받은 그룹 카테고리가 없는 경우 각각 빈 배열([])을 반환합니다."
     )
     @GetMapping
-    public ResponseEntity<SuccessResponseDTO<CategoryDTO>> getCategories(
+    public ResponseEntity<SuccessResponse<CategoryDTO>> getCategories(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
         CategoryDTO categoryDTO = categoryService.getCategories(email);
 
-        SuccessResponseDTO<CategoryDTO> successResponse = SuccessResponseDTO.<CategoryDTO>builder()
+        SuccessResponse<CategoryDTO> successResponse = SuccessResponse.<CategoryDTO>builder()
                 .status(SuccessCode.CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(categoryDTO)
@@ -99,14 +99,14 @@ public class CategoryController {
                     "일반 카테고리가 없는 경우 각각 빈 배열([])을 반환합니다."
     )
     @GetMapping("/general")
-    public ResponseEntity<SuccessResponseDTO<List<GeneralCategoryDTO>>> getGeneralCategories(
+    public ResponseEntity<SuccessResponse<List<GeneralCategoryDTO>>> getGeneralCategories(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
         User user = userService.findUserByEmail(email);
         List<GeneralCategoryDTO> categories = categoryService.getGeneralCategories(user);
 
-        SuccessResponseDTO<List<GeneralCategoryDTO>> successResponse = SuccessResponseDTO.<List<GeneralCategoryDTO>>builder()
+        SuccessResponse<List<GeneralCategoryDTO>> successResponse = SuccessResponse.<List<GeneralCategoryDTO>>builder()
                 .status(SuccessCode.GENERAL_CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.GENERAL_CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(categories)
@@ -120,14 +120,14 @@ public class CategoryController {
                     "그룹 카테고리가 없는 경우 각각 빈 배열([])을 반환합니다."
     )
     @GetMapping("/groups")
-    public ResponseEntity<SuccessResponseDTO<List<GroupCategoryDTO>>> getGroupCategories(
+    public ResponseEntity<SuccessResponse<List<GroupCategoryDTO>>> getGroupCategories(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
         User user = userService.findUserByEmail(email);
         List<GroupCategoryDTO> categories = categoryService.getGroupCategories(user);
 
-        SuccessResponseDTO<List<GroupCategoryDTO>> successResponse = SuccessResponseDTO.<List<GroupCategoryDTO>>builder()
+        SuccessResponse<List<GroupCategoryDTO>> successResponse = SuccessResponse.<List<GroupCategoryDTO>>builder()
                 .status(SuccessCode.GROUP_CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.GROUP_CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(categories)
@@ -141,14 +141,14 @@ public class CategoryController {
                     "응답하지 않은 초대 그룹 카테고리가 없는 경우 빈 배열([])을 반환합니다."
     )
     @GetMapping("/groups/invitations")
-    public ResponseEntity<SuccessResponseDTO<List<InvitedGroupDTO>>> getInvitedGroupCategories(
+    public ResponseEntity<SuccessResponse<List<InvitedGroupDTO>>> getInvitedGroupCategories(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
         User user = userService.findUserByEmail(email);
         List<InvitedGroupDTO> groupCategories = categoryService.getInvitedGroupCategories(user);
 
-        SuccessResponseDTO<List<InvitedGroupDTO>> successResponse = SuccessResponseDTO.<List<InvitedGroupDTO>>builder()
+        SuccessResponse<List<InvitedGroupDTO>> successResponse = SuccessResponse.<List<InvitedGroupDTO>>builder()
                 .status(SuccessCode.INVITED_CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.INVITED_CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(groupCategories)
@@ -162,14 +162,14 @@ public class CategoryController {
                     "일반 카테고리는 멤버에 빈 배열([])을 반환합니다."
     )
     @GetMapping("/{categoryId}")
-    public ResponseEntity<SuccessResponseDTO<CategoryDetailDTO>> getCategoryDetail(
+    public ResponseEntity<SuccessResponse<CategoryDetailDTO>> getCategoryDetail(
             @PathVariable Long categoryId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
         CategoryDetailDTO categoryDetailDTO = categoryService.getCategoryDetail(categoryId, email);
 
-        SuccessResponseDTO<CategoryDetailDTO> successResponse = SuccessResponseDTO.<CategoryDetailDTO>builder()
+        SuccessResponse<CategoryDetailDTO> successResponse = SuccessResponse.<CategoryDetailDTO>builder()
                 .status(SuccessCode.CATEGORY_DETAIL_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_DETAIL_FETCH_SUCCESS.getMessage())
                 .data(categoryDetailDTO)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
@@ -103,7 +103,7 @@ public class CategoryController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
-        User user = userService.findByEmail(email);
+        User user = userService.findUserByEmail(email);
         List<GeneralCategoryDTO> categories = categoryService.getGeneralCategories(user);
 
         SuccessResponseDTO<List<GeneralCategoryDTO>> successResponse = SuccessResponseDTO.<List<GeneralCategoryDTO>>builder()
@@ -124,7 +124,7 @@ public class CategoryController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
-        User user = userService.findByEmail(email);
+        User user = userService.findUserByEmail(email);
         List<GroupCategoryDTO> categories = categoryService.getGroupCategories(user);
 
         SuccessResponseDTO<List<GroupCategoryDTO>> successResponse = SuccessResponseDTO.<List<GroupCategoryDTO>>builder()
@@ -145,7 +145,7 @@ public class CategoryController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String email = customUserDetails.getUsername();
-        User user = userService.findByEmail(email);
+        User user = userService.findUserByEmail(email);
         List<InvitedGroupDTO> groupCategories = categoryService.getInvitedGroupCategories(user);
 
         SuccessResponseDTO<List<InvitedGroupDTO>> successResponse = SuccessResponseDTO.<List<InvitedGroupDTO>>builder()

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
@@ -47,7 +47,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Transactional
     public void createCategory(String hostEmail, CategoryCreationDTO categoryCreationDTO){
 
-        User host = userService.findByEmail(hostEmail);
+        User host = userService.findUserByEmail(hostEmail);
 
         // 일반/그룹 카테고리 생성
         Category category = createNewCategory(
@@ -111,7 +111,7 @@ public class CategoryServiceImpl implements CategoryService {
                 throw new CustomException(ErrorCode.CATEGORY_MEMBER_NOT_FOLLOWED);
             }
 
-            User member = userService.findByUserId(memberId);
+            User member = userService.findUserById(memberId);
             createGroupMember(category, member, GroupInvitationStatus.INVITED, GroupRole.MEMBER);
         }
     }
@@ -145,7 +145,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     public CategoryDTO getCategories(String email) {
         // 사용자 조회
-        User user = userService.findByEmail(email);
+        User user = userService.findUserByEmail(email);
 
         // 일반 카테고리
         List<GeneralCategoryDTO> generalCategories = getGeneralCategories(user);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -33,15 +33,15 @@ public class AdminController {
     /**
      * 관리자 회원가입 API
      *
-     * @param adminRequest AdminDTO 객체
+     * @param request AdminRequest 객체
      * @param profileImage 관리자 프로필 이미지 파일
-     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
+     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse
      */
     @Operation(
             summary = "관리자 회원가입",
             description = "관리자 회원가입을 수행합니다. <br>"
                     + "관리자의 이메일은 @pomorodo.shop 도메인으로 제한됩니다. <br>"
-                    + "성공 시에는 TokenDTO를 포함하는 SuccessResponseDTO를 반환합니다."
+                    + "성공 시에는 TokenResponse를 포함하는 SuccessResponse를 반환합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
@@ -50,30 +50,30 @@ public class AdminController {
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponseDTO<TokenResponse>> adminJoin(
-            @Valid @RequestPart AdminRequest adminRequest,
+            @Valid @RequestPart AdminRequest request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
 
-        TokenResponse jwtResponse = adminService.adminJoin(adminRequest, profileImage);
+        TokenResponse jwtResponse = adminService.adminJoin(request, profileImage);
         SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
                 .status(SuccessCode.ADMIN_SIGNUP_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
                 .data(jwtResponse)
                 .build();
-        log.info("관리자 회원가입 성공: {}", adminRequest.getEmail());
+        log.info("관리자 회원가입 성공: {}", request.getEmail());
         return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);
     }
 
     /**
      * 관리자 로그인 API
      *
-     * @param request AdminDTO 객체
-     * @return 성공 시 TokenDTO를 포함하는 SuccessResponseDTO
+     * @param request AdminRequest 객체
+     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse
      */
     @Operation(
             summary = "관리자 로그인",
             description = "관리자 로그인을 수행합니다. <br>"
-                    + "성공 시에는 TokenDTO를 포함하는 SuccessResponseDTO를 반환합니다."
+                    + "성공 시에는 TokenResponse를 포함하는 SuccessResponse를 반환합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -4,7 +4,7 @@ import com.tico.pomoro_do.domain.auth.dto.response.TokenResponse;
 import com.tico.pomoro_do.domain.user.dto.request.AdminRequest;
 import com.tico.pomoro_do.domain.user.service.AdminService;
 import com.tico.pomoro_do.global.code.SuccessCode;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -35,7 +35,7 @@ public class AdminController {
      *
      * @param request AdminRequest 객체
      * @param profileImage 관리자 프로필 이미지 파일
-     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse
+     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse 반환
      */
     @Operation(
             summary = "관리자 회원가입",
@@ -49,13 +49,13 @@ public class AdminController {
             @ApiResponse(responseCode = "409", description = "이미 등록된 사용자")
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponseDTO<TokenResponse>> adminJoin(
+    public ResponseEntity<SuccessResponse<TokenResponse>> adminJoin(
             @Valid @RequestPart AdminRequest request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
 
         TokenResponse jwtResponse = adminService.adminJoin(request, profileImage);
-        SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
+        SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                 .status(SuccessCode.ADMIN_SIGNUP_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
                 .data(jwtResponse)
@@ -68,7 +68,7 @@ public class AdminController {
      * 관리자 로그인 API
      *
      * @param request AdminRequest 객체
-     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse
+     * @return 성공 시 TokenResponse를 포함하는 SuccessResponse 반환
      */
     @Operation(
             summary = "관리자 로그인",
@@ -82,12 +82,12 @@ public class AdminController {
             @ApiResponse(responseCode = "403", description = "관리자 권한이 없음")
     })
     @PostMapping("/login")
-    public ResponseEntity<SuccessResponseDTO<TokenResponse>> adminLogin(
+    public ResponseEntity<SuccessResponse<TokenResponse>> adminLogin(
             @Valid @RequestBody AdminRequest request
     ) {
         log.info("관리자 로그인 요청: {}", request.getEmail());
         TokenResponse jwtResponse = adminService.adminLogin(request);
-        SuccessResponseDTO<TokenResponse> successResponse = SuccessResponseDTO.<TokenResponse>builder()
+        SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                 .status(SuccessCode.ADMIN_LOGIN_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_LOGIN_SUCCESS.getMessage())
                 .data(jwtResponse)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -1,10 +1,10 @@
 package com.tico.pomoro_do.domain.user.controller;
 
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 import com.tico.pomoro_do.domain.user.service.FollowService;
 import com.tico.pomoro_do.domain.auth.security.CustomUserDetails;
 import com.tico.pomoro_do.global.code.SuccessCode;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -46,14 +46,14 @@ public class FollowController {
             @ApiResponse(responseCode = "409", description = "이미 팔로우 중인 사용자")
     })
     @PostMapping("/{userId}/follow")
-    public ResponseEntity<SuccessResponseDTO<String>> follow(
+    public ResponseEntity<SuccessResponse<String>> follow(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ) {
         // 현재 로그인한 사용자 ID
         Long currentUserId = customUserDetails.getUserId();
         followService.followUser(currentUserId, userId);
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(SuccessCode.FOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOW_SUCCESS.getMessage())
                 .data(SuccessCode.FOLLOW_SUCCESS.name())
@@ -66,20 +66,20 @@ public class FollowController {
      *
      * @param customUserDetails 현재 인증된 사용자의 정보
      * @param userId 팔로우 취소할 사용자의 ID
-     * @return 성공 시 성공 메시지를 포함한 SuccessResponseDTO 반환
+     * @return 성공 시 성공 메시지를 포함한 SuccessResponse 반환
      */
     @Operation(
             summary = "현재 사용자가 특정 사용자를 팔로우 취소",
             description = "현재 인증된 사용자가 팔로우하는 특정 사용자를 팔로우 취소합니다."
     )
     @DeleteMapping("/{userId}/follow")
-    public ResponseEntity<SuccessResponseDTO<String>> unfollow(
+    public ResponseEntity<SuccessResponse<String>> unfollow(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ){
         Long currentUserId = customUserDetails.getUserId();
         followService.unfollowUser(currentUserId, userId);
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(SuccessCode.UNFOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.UNFOLLOW_SUCCESS.getMessage())
                 .data(SuccessCode.UNFOLLOW_SUCCESS.name())
@@ -92,7 +92,7 @@ public class FollowController {
      * 현재 사용자를 팔로우 중인 사용자 목록을 조회하는 API
      *
      * @param customUserDetails 현재 인증된 사용자의 정보
-     * @return 사용자를 팔로우 중인 사용자 목록을 포함한 List<FollowResponse> 반환
+     * @return 사용자를 팔로우 중인 사용자 목록을 포함한 List<UserProfileResponse> 반환
      */
     @Operation(
             summary = "현재 사용자의 팔로워 목록 조회 (내 팔로워 조회)",
@@ -104,13 +104,13 @@ public class FollowController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @GetMapping("/me/followers")
-    public ResponseEntity<SuccessResponseDTO<List<FollowResponse>>> getFollowers(
+    public ResponseEntity<SuccessResponse<List<UserProfileResponse>>> getFollowers(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         Long currentUserId = customUserDetails.getUserId();
-        List<FollowResponse> followersList = followService.getFollowers(currentUserId);
+        List<UserProfileResponse> followersList = followService.getFollowers(currentUserId);
 
-        SuccessResponseDTO<List<FollowResponse>> successResponse = SuccessResponseDTO.<List<FollowResponse>>builder()
+        SuccessResponse<List<UserProfileResponse>> successResponse = SuccessResponse.<List<UserProfileResponse>>builder()
                 .status(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getMessage())
                 .data(followersList)
@@ -123,7 +123,7 @@ public class FollowController {
      * 사용자가 팔로우 중인 사용자 목록을 조회하는 API
      *
      * @param customUserDetails 현재 인증된 사용자의 정보
-     * @return 사용자가 팔로우 중인 사용자 목록을 포함한 List<FollowResponse> 반환
+     * @return 사용자가 팔로우 중인 사용자 목록을 포함한 List<UserProfileResponse> 반환
      */
     @Operation(
             summary = "현재 사용자의 팔로우 목록 조회 (내 팔로잉 조회)",
@@ -135,13 +135,13 @@ public class FollowController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @GetMapping("/me/followings")
-    public ResponseEntity<SuccessResponseDTO<List<FollowResponse>>> getFollowings(
+    public ResponseEntity<SuccessResponse<List<UserProfileResponse>>> getFollowings(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         Long currentUserId = customUserDetails.getUserId();
-        List<FollowResponse> followingList = followService.getFollowings(currentUserId);
+        List<UserProfileResponse> followingList = followService.getFollowings(currentUserId);
 
-        SuccessResponseDTO<List<FollowResponse>> successResponse = SuccessResponseDTO.<List<FollowResponse>>builder()
+        SuccessResponse<List<UserProfileResponse>> successResponse = SuccessResponse.<List<UserProfileResponse>>builder()
                 .status(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getMessage())
                 .data(followingList)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -46,7 +46,7 @@ public class FollowController {
             @ApiResponse(responseCode = "409", description = "이미 팔로우 중인 사용자")
     })
     @PostMapping("/{userId}/follow")
-    public ResponseEntity<SuccessResponse<String>> follow(
+    public ResponseEntity<SuccessResponse<String>> followUser(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ) {
@@ -73,7 +73,7 @@ public class FollowController {
             description = "현재 인증된 사용자가 팔로우하는 특정 사용자를 팔로우 취소합니다."
     )
     @DeleteMapping("/{userId}/follow")
-    public ResponseEntity<SuccessResponse<String>> unfollow(
+    public ResponseEntity<SuccessResponse<String>> unfollowUser(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ){

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -30,8 +30,8 @@ public class FollowController {
      * 현재 인증된 사용자가 다른 사용자를 팔로우하는 API
      *
      * @param customUserDetails 현재 인증된 사용자의 정보
-     * @param userId 팔로우할 사용자의 ID
-     * @return 성공 시 성공 메시지를 포함한 SuccessResponseDTO 반환
+     * @param userId 팔로우 당하는 사용자 ID
+     * @return 성공 시 성공 메시지를 포함한 SuccessResponse 반환
      */
     @Operation(
             summary = "현재 사용자가 특정 사용자를 팔로우",
@@ -50,8 +50,9 @@ public class FollowController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ) {
-        String username = customUserDetails.getUsername();
-        followService.follow(username, userId);
+        // 현재 로그인한 사용자 ID
+        Long currentUserId = customUserDetails.getUserId();
+        followService.followUser(currentUserId, userId);
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.FOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOW_SUCCESS.getMessage())
@@ -76,8 +77,8 @@ public class FollowController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ){
-        String username = customUserDetails.getUsername();
-        followService.unfollow(username, userId);
+        Long currentUserId = customUserDetails.getUserId();
+        followService.unfollowUser(currentUserId, userId);
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.UNFOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.UNFOLLOW_SUCCESS.getMessage())
@@ -106,8 +107,8 @@ public class FollowController {
     public ResponseEntity<SuccessResponseDTO<List<FollowResponse>>> getFollowers(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
-        String username = customUserDetails.getUsername();
-        List<FollowResponse> followersList = followService.getFollowers(username);
+        Long currentUserId = customUserDetails.getUserId();
+        List<FollowResponse> followersList = followService.getFollowers(currentUserId);
 
         SuccessResponseDTO<List<FollowResponse>> successResponse = SuccessResponseDTO.<List<FollowResponse>>builder()
                 .status(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getHttpStatus().value())
@@ -137,8 +138,8 @@ public class FollowController {
     public ResponseEntity<SuccessResponseDTO<List<FollowResponse>>> getFollowings(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        String username = customUserDetails.getUsername();
-        List<FollowResponse> followingList = followService.getFollowings(username);
+        Long currentUserId = customUserDetails.getUserId();
+        List<FollowResponse> followingList = followService.getFollowings(currentUserId);
 
         SuccessResponseDTO<List<FollowResponse>> successResponse = SuccessResponseDTO.<List<FollowResponse>>builder()
                 .status(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getHttpStatus().value())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
@@ -4,7 +4,7 @@ import com.tico.pomoro_do.domain.user.dto.response.ImageResponse;
 import com.tico.pomoro_do.domain.user.service.ImageService;
 import com.tico.pomoro_do.global.code.SuccessCode;
 import com.tico.pomoro_do.global.enums.S3Folder;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -33,7 +33,7 @@ public class ImageController {
      * 이미지 업로드 엔드포인트
      *
      * @param image MultipartRequest로 받은 파일 업로드 요청
-     * @return ResponseEntity 성공 응답 DTO를 포함한 ResponseEntity 객체
+     * @return 성공 시 ImageResponse를 포함하는 SuccessResponse 반환
      */
     @Operation(
             summary = "이미지 업로드",
@@ -45,7 +45,7 @@ public class ImageController {
             @ApiResponse(responseCode = "400", description = "유효하지 않은 이미지 파일"),
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponseDTO<ImageResponse>> imageUpload(
+    public ResponseEntity<SuccessResponse<ImageResponse>> imageUpload(
             @RequestParam("image") MultipartFile image
     ) {
 
@@ -55,7 +55,7 @@ public class ImageController {
                 .imageUrl(imageUrl)
                 .build();
 
-        SuccessResponseDTO<ImageResponse> response = SuccessResponseDTO.<ImageResponse>builder()
+        SuccessResponse<ImageResponse> response = SuccessResponse.<ImageResponse>builder()
                 .status(SuccessCode.IMAGE_UPLOAD_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.IMAGE_UPLOAD_SUCCESS.getMessage())
                 .data(imageResponse)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -84,7 +84,7 @@ public class UserController {
             @RequestHeader("Device-ID") String deviceId,
             @RequestHeader("Refresh-Token") String refreshToken
     ) {
-        userService.deleteUser(customUserDetails.getUsername(), deviceId, refreshToken);
+        userService.deleteUser(customUserDetails.getUserId(), deviceId, refreshToken);
 
         SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
                 .status(SuccessCode.USER_DELETION_SUCCESS.getHttpStatus().value())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -1,11 +1,11 @@
 package com.tico.pomoro_do.domain.user.controller;
 
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailResponse;
 import com.tico.pomoro_do.domain.user.service.UserService;
 import com.tico.pomoro_do.domain.auth.security.CustomUserDetails;
 import com.tico.pomoro_do.global.code.SuccessCode;
-import com.tico.pomoro_do.global.response.SuccessResponseDTO;
+import com.tico.pomoro_do.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,18 +25,22 @@ public class UserController {
 
     /**
      * 인증된 사용자의 상세 정보를 조회합니다.
+     * 이메일, 닉네임, 프로필 이미지, 팔로워/팔로잉 수를 포함합니다.
      *
      * @param customUserDetails 인증된 사용자 정보
-     * @return 성공 시 사용자 상세 정보가 담긴 SuccessResponseDTO 반환
+     * @return 성공 시 사용자 상세 정보가 담긴 SuccessResponse 반환
      */
-    @Operation(summary = "현재 사용자 정보 조회", description = "인증된 사용자의 상세 정보를 조회합니다.")
+    @Operation(
+            summary = "로그인 사용자 상세 정보 조회",
+            description = "현재 로그인한 사용자의 이메일, 닉네임, 프로필 이미지, 팔로워/팔로잉 수를 조회합니다."
+    )
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponseDTO<UserDetailResponse>> getMyDetail(
+    public ResponseEntity<SuccessResponse<UserDetailResponse>> getUserDetail(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
 
-        UserDetailResponse userDetailResponse = userService.getMyProfile(customUserDetails.getUserId());
-        SuccessResponseDTO<UserDetailResponse> successResponse = SuccessResponseDTO.<UserDetailResponse>builder()
+        UserDetailResponse userDetailResponse = userService.getUserDetail(customUserDetails.getUserId());
+        SuccessResponse<UserDetailResponse> successResponse = SuccessResponse.<UserDetailResponse>builder()
                 .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
                 .data(userDetailResponse)
@@ -47,19 +51,24 @@ public class UserController {
     }
 
     /**
-     * 특정 사용자의 상세 정보 및 팔로우 상태를 조회합니다.
+     * 특정 사용자의 프로필 정보를 조회합니다.
+     * 닉네임, 프로필 이미지, 팔로우 상태를 포함합니다.
      *
+     * @param customUserDetails 인증된 사용자 정보
      * @param userId 조회할 사용자 ID
-     * @return 성공 시 사용자 정보와 팔로우 상태가 담긴 SuccessResponseDTO 반환
+     * @return 성공 시 사용자 프로필 정보가 담긴 SuccessResponse 반환
      */
-    @Operation(summary = "특정 사용자 정보 조회", description = "주어진 사용자 ID에 대한 상세 정보 및 팔로우 상태를 조회합니다.")
+    @Operation(
+            summary = "특정 사용자 프로필 조회",
+            description = "특정 사용자의 닉네임, 프로필 이미지와 현재 사용자의 해당 사용자에 대한 팔로우 상태를 조회합니다."
+    )
     @GetMapping("/{userId}")
-    public ResponseEntity<SuccessResponseDTO<FollowResponse>> getUserDetail(
+    public ResponseEntity<SuccessResponse<UserProfileResponse>> getUserProfile(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ) {
-        FollowResponse response = userService.getUserProfile(customUserDetails.getUserId(), userId);
-        SuccessResponseDTO<FollowResponse> successResponse = SuccessResponseDTO.<FollowResponse>builder()
+        UserProfileResponse response = userService.getUserProfile(customUserDetails.getUserId(), userId);
+        SuccessResponse<UserProfileResponse> successResponse = SuccessResponse.<UserProfileResponse>builder()
                 .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
                 .data(response)
@@ -74,18 +83,18 @@ public class UserController {
      * @param customUserDetails 현재 인증된 사용자 정보를 담고 있는 CustomUserDetails 객체
      * @param deviceId 사용자 디바이스의 고유 식별자
      * @param refreshToken 현재 사용자 디바이스의 리프레시 토큰
-     * @return 삭제 성공 시 SuccessResponseDTO를 포함하는 ResponseEntity 반환
+     * @return 삭제 성공 시 성공 메시지를 포함한 SuccessResponse 반환
      */
     @Operation(summary = "현재 사용자 계정 삭제", description = "현재 인증된 사용자의 계정을 삭제합니다.")
     @DeleteMapping("/me")
-    public ResponseEntity<SuccessResponseDTO<String>> deleteUser(
+    public ResponseEntity<SuccessResponse<String>> deleteUser(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestHeader("Device-ID") String deviceId,
             @RequestHeader("Refresh-Token") String refreshToken
     ) {
         userService.deleteUser(customUserDetails.getUserId(), deviceId, refreshToken);
 
-        SuccessResponseDTO<String> successResponse = SuccessResponseDTO.<String>builder()
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
                 .status(SuccessCode.USER_DELETION_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_DELETION_SUCCESS.getMessage())
                 .data(SuccessCode.USER_DELETION_SUCCESS.name())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
 
-        UserDetailResponse userDetailResponse = userService.getMyDetail(customUserDetails.getUsername());
+        UserDetailResponse userDetailResponse = userService.getMyProfile(customUserDetails.getUserId());
         SuccessResponseDTO<UserDetailResponse> successResponse = SuccessResponseDTO.<UserDetailResponse>builder()
                 .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
@@ -58,8 +58,7 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long userId
     ) {
-        String email = customUserDetails.getUsername();
-        FollowResponse response = userService.getUserDetail(email, userId);
+        FollowResponse response = userService.getUserProfile(customUserDetails.getUserId(), userId);
         SuccessResponseDTO<FollowResponse> successResponse = SuccessResponseDTO.<FollowResponse>builder()
                 .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/UserDetailResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/UserDetailResponse.java
@@ -4,6 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 현재 로그인한 사용자의 상세 정보를 담는 응답 클래스
+ * 이메일과 팔로우 카운트 등 개인화된 상세 정보를 포함합니다.
+ */
 @Getter
 public class UserDetailResponse {
 
@@ -32,5 +36,4 @@ public class UserDetailResponse {
         this.followingCount = followingCount;
         this.followerCount = followerCount;
     }
-
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/UserProfileResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/response/UserProfileResponse.java
@@ -3,16 +3,20 @@ package com.tico.pomoro_do.domain.user.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 다른 사용자의 프로필 정보를 담는 응답 클래스
+ * 공개적으로 표시 가능한 기본 정보와 팔로우 상태를 포함합니다.
+ */
 @Getter
-public class FollowResponse {
+public class UserProfileResponse {
 
     private final Long userId; // 사용자 ID
-    private final String nickname; // 사용자 이름
+    private final String nickname; // 사용자 닉네임
     private final String profileImageUrl; // 프로필 이미지 URL
     private final boolean following; // 현재 로그인한 사용자가 이 사용자를 팔로우하고 있는지 여부
 
     @Builder
-    public FollowResponse(Long userId, String nickname, String profileImageUrl, boolean following) {
+    public UserProfileResponse(Long userId, String nickname, String profileImageUrl, boolean following) {
         this.userId = userId;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
@@ -13,6 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
 
     boolean existsByEmail(String email);
+    boolean existsById(Long id);
 
     void deleteByEmail(String email);
     void deleteById(Long id);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/repository/UserRepository.java
@@ -10,10 +10,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     //email을 받아 DB 테이블에서 회원을 조회하는 메소드 작성
     Optional<User> findByEmail(String email);
 
-    Optional<User> findById(Long userId);
+    Optional<User> findById(Long id);
 
     boolean existsByEmail(String email);
 
     void deleteByEmail(String email);
+    void deleteById(Long id);
 
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
@@ -42,7 +42,7 @@ public class AdminServiceImpl implements AdminService {
         // 관리자 회원가입 이메일 도메인 검증
         validateAdminEmailDomain(domain);
         // 관리자 이메일 가입 여부 검증
-        userService.isEmailRegistered(email);
+        userService.verifyEmailNotRegistered(email);
 
         // profileImage URL 가져오기
         String profileImageUrl;
@@ -114,7 +114,7 @@ public class AdminServiceImpl implements AdminService {
      * @throws CustomException 사용자가 존재하지 않거나 관리자가 아닌 경우 예외 발생
      */
     private User validateAdminUser(String email, String nickname) {
-        User admin = userService.findByEmail(email);
+        User admin = userService.findUserByEmail(email);
 
         if (!admin.getRole().equals(UserRole.ADMIN)) {
             log.error("관리자 권한 없음: {}", email);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminServiceImpl.java
@@ -5,7 +5,6 @@ import com.tico.pomoro_do.domain.auth.service.AuthService;
 import com.tico.pomoro_do.domain.auth.service.TokenService;
 import com.tico.pomoro_do.domain.user.dto.request.AdminRequest;
 import com.tico.pomoro_do.domain.user.entity.User;
-import com.tico.pomoro_do.domain.user.repository.UserRepository;
 import com.tico.pomoro_do.global.code.ErrorCode;
 import com.tico.pomoro_do.global.enums.S3Folder;
 import com.tico.pomoro_do.global.enums.UserRole;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -62,7 +60,7 @@ public class AdminServiceImpl implements AdminService {
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(email.getBytes()).toString() + "_" + role;
 
-        return tokenService.createAuthTokens(email, String.valueOf(UserRole.ADMIN), deviceId);
+        return tokenService.createAuthTokens(admin.getId(), email, String.valueOf(UserRole.ADMIN), deviceId);
     }
 
     // 관리자 로그인
@@ -77,12 +75,12 @@ public class AdminServiceImpl implements AdminService {
         // 로그인 이메일 검증 (관리자 도메인)
         validateAdminEmailDomain(domain);
         // 관리자 로그인 검증
-        validateAdminUser(email, nickname);
+        User admin = validateAdminUser(email, nickname);
         // 역할
         String role = String.valueOf(UserRole.ADMIN);
         // 관리자 고유 번호: UUID 기반 + 역할명
         String deviceId = UUID.nameUUIDFromBytes(email.getBytes()).toString() + "_" + role;
-        return tokenService.createAuthTokens(email, role, deviceId);
+        return tokenService.createAuthTokens(admin.getId(), email, role, deviceId);
     }
 
     /**
@@ -115,7 +113,7 @@ public class AdminServiceImpl implements AdminService {
      * @param nickname 사용자 닉네임
      * @throws CustomException 사용자가 존재하지 않거나 관리자가 아닌 경우 예외 발생
      */
-    private void validateAdminUser(String email, String nickname) {
+    private User validateAdminUser(String email, String nickname) {
         User admin = userService.findByEmail(email);
 
         if (!admin.getRole().equals(UserRole.ADMIN)) {
@@ -126,5 +124,6 @@ public class AdminServiceImpl implements AdminService {
             log.error("닉네임 불일치: {}", email);
             throw new CustomException(ErrorCode.ADMIN_LOGIN_FAILED);
         }
+        return admin;
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
@@ -7,43 +7,43 @@ import java.util.List;
 public interface FollowService {
 
     /**
-     * 특정 사용자 팔로우
+     * 특정 사용자를 팔로우
      *
-     * @param followerUserEmail 팔로우하는 사용자 이메일
-     * @param followingId   팔로우될 사용자 ID
+     * @param followerId 팔로우하는 사용자 ID
+     * @param followingId 팔로우 대상 사용자 ID
      */
-    void follow(String followerUserEmail, Long followingId);
+    void followUser(Long followerId, Long followingId);
 
     /**
-     * 특정 사용자 팔로우 취소
+     * 특정 사용자를 언팔로우
      *
-     * @param followerUserEmail 현재 사용자 이메일
-     * @param followingId   팔로우 취소하는 사용자 ID
+     * @param followerId 팔로우 취소하는 사용자 ID
+     * @param followingId 팔로우 대상 사용자 ID
      */
-    void unfollow(String followerUserEmail, Long followingId);
+    void unfollowUser(Long followerId, Long followingId);
 
     /**
-     * 사용자를 팔로우 중인 사용자 목록을 조회
+     * 사용자를 팔로우하는 사용자 목록 조회 (팔로워 조회)
      *
-     * @param email 현재 인증된 사용자 이메일
-     * @return FollowResponse 객체 리스트 반환
+     * @param userId 현재 사용자 ID
+     * @return 사용자를 팔로우하는 사용자 목록 (FollowResponse 리스트)
      */
-    List<FollowResponse> getFollowers(String email);
+    List<FollowResponse> getFollowers(Long userId);
 
     /**
-     * 사용자가 팔로우 중인 사용자 목록을 조회
+     * 사용자가 팔로우하는 사용자 목록 조회 (팔로잉 조회)
      *
-     * @param email 현재 인증된 사용자 이메일
-     * @return FollowResponse 객체 리스트 반환
+     * @param userId 현재 사용자 ID
+     * @return 사용자가 팔로우하는 사용자 목록 (FollowResponse 리스트)
      */
-    List<FollowResponse> getFollowings(String email);
+    List<FollowResponse> getFollowings(Long userId);
 
     /**
      * 특정 사용자가 타겟 사용자를 팔로우하고 있는지 여부
      *
      * @param currentUserId 현재 인증된 사용자 ID
      * @param targetUserId 팔로우 여부를 확인할 대상의 사용자 ID
-     * @return 팔로우 여부 반환
+     * @return 팔로우 여부 반환 (true: 팔로우 중, false: 팔로우 안 함)
      */
     boolean isFollowing(Long currentUserId, Long targetUserId);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowService.java
@@ -1,6 +1,6 @@
 package com.tico.pomoro_do.domain.user.service;
 
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 
 import java.util.List;
 
@@ -26,17 +26,17 @@ public interface FollowService {
      * 사용자를 팔로우하는 사용자 목록 조회 (팔로워 조회)
      *
      * @param userId 현재 사용자 ID
-     * @return 사용자를 팔로우하는 사용자 목록 (FollowResponse 리스트)
+     * @return 사용자를 팔로우하는 사용자 목록 (UserProfileResponse 리스트)
      */
-    List<FollowResponse> getFollowers(Long userId);
+    List<UserProfileResponse> getFollowers(Long userId);
 
     /**
      * 사용자가 팔로우하는 사용자 목록 조회 (팔로잉 조회)
      *
      * @param userId 현재 사용자 ID
-     * @return 사용자가 팔로우하는 사용자 목록 (FollowResponse 리스트)
+     * @return 사용자가 팔로우하는 사용자 목록 (UserProfileResponse 리스트)
      */
-    List<FollowResponse> getFollowings(Long userId);
+    List<UserProfileResponse> getFollowings(Long userId);
 
     /**
      * 특정 사용자가 타겟 사용자를 팔로우하고 있는지 여부

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
@@ -1,6 +1,6 @@
 package com.tico.pomoro_do.domain.user.service;
 
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 import com.tico.pomoro_do.domain.user.entity.Follow;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.domain.user.repository.FollowRepository;
@@ -80,14 +80,14 @@ public class FollowServiceImpl implements FollowService {
 
     // 나를 팔로우하고 있는 사용자 목록을 조회
     @Override
-    public List<FollowResponse> getFollowers(Long userId) {
+    public List<UserProfileResponse> getFollowers(Long userId) {
         // 사용자를 팔로우하는 사용자 목록을 조회
         return getFollowList(userId, false);
     }
 
     // 내가 팔로우하고 있는 사용자 목록을 조회
     @Override
-    public List<FollowResponse> getFollowings(Long userId) {
+    public List<UserProfileResponse> getFollowings(Long userId) {
         // 팔로우 중인 사용자 목록을 조회
         return getFollowList(userId, true);
     }
@@ -97,9 +97,9 @@ public class FollowServiceImpl implements FollowService {
      *
      * @param userId 현재 사용자 ID
      * @param isFollowings true: 팔로잉 목록, false: 팔로워 목록
-     * @return FollowResponse 리스트 반환
+     * @return UserProfileResponse 리스트 반환
      */
-    private List<FollowResponse> getFollowList(Long userId, boolean isFollowings) {
+    private List<UserProfileResponse> getFollowList(Long userId, boolean isFollowings) {
         // 사용자 정보 조회
         User user = userService.findUserById(userId);
 
@@ -111,19 +111,19 @@ public class FollowServiceImpl implements FollowService {
         // Follow 엔티티 리스트를 FollowResponse 리스트로 변환하여 반환
         return followList.stream()
                 .map(follow -> convertToFollowResponse(follow, isFollowings, userId)) // DTO 변환
-                .sorted(Comparator.comparing(FollowResponse::getNickname)) // 닉네임 기준으로 정렬
+                .sorted(Comparator.comparing(UserProfileResponse::getNickname)) // 닉네임 기준으로 정렬
                 .collect(Collectors.toList()); // 리스트로 수집하여 반환
     }
 
     /**
-     * Follow 엔티티를 FollowResponse DTO로 변환
+     * Follow 엔티티를 UserProfileResponse DTO로 변환
      *
      * @param follow Follow 엔티티
      * @param isFollowings 팔로우 목록 여부
      * @param currentUserId 현재 사용자 ID
-     * @return FollowResponse DTO
+     * @return UserProfileResponse DTO
      */
-    private FollowResponse convertToFollowResponse(Follow follow, boolean isFollowings, Long currentUserId) {
+    private UserProfileResponse convertToFollowResponse(Follow follow, boolean isFollowings, Long currentUserId) {
         // 타겟 유저를 결정: 팔로우 목록일 경우 수신자, 팔로워 목록일 경우 발신자
         User targetUser = isFollowings ? follow.getFollowing() : follow.getFollower();
 
@@ -131,7 +131,7 @@ public class FollowServiceImpl implements FollowService {
         boolean isFollowing = isFollowings || isFollowing(currentUserId, targetUser.getId());
 
         // FollowUserDTO 객체 생성 및 반환
-        return FollowResponse.builder()
+        return UserProfileResponse.builder()
                 .userId(targetUser.getId()) // 타겟 유저의 ID 설정
                 .nickname(targetUser.getNickname()) // 타겟 유저의 닉네임 설정
                 .profileImageUrl(targetUser.getProfileImageUrl()) // 타겟 유저의 프로필 이미지 URL 설정

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/FollowServiceImpl.java
@@ -28,22 +28,22 @@ public class FollowServiceImpl implements FollowService {
     // 특정 사용자를 팔로우
     @Override
     @Transactional
-    public void follow(String followerUserEmail, Long followingId) {
+    public void followUser(Long followerId, Long followingId) {
         // 유효성 검사 (null 또는 음수 체크)
         ValidationUtils.validateUserId(followingId);
 
-        User follower = userService.findByEmail(followerUserEmail);
-        User following = userService.findByUserId(followingId);
+        User follower = userService.findUserById(followerId);
+        User following = userService.findUserById(followingId);
 
         // 본인을 팔로우 하는 지 확인
-        if (follower.equals(following)) {
-            log.warn("사용자 '{}'가 본인을 팔로우하려고 시도했습니다.", followerUserEmail);
+        if (followerId.equals(followingId)) {
+            log.warn("[Follow] 본인 팔로우 시도: userId={}", followerId);
             throw new CustomException(ErrorCode.SELF_FOLLOW_NOT_ALLOWED);
         }
 
         // 이미 팔로우 중인지 확인
-        if (isFollowing(follower.getId(), followingId)) {
-            log.warn("사용자 '{}'가 이미 사용자 ID '{}'를 팔로우했습니다.", followerUserEmail, followingId);
+        if (isFollowing(followerId, followingId)) {
+            log.warn("[Follow] 이미 팔로우 중: followerId={}, followingId={}", followerId, followingId);
             throw new CustomException(ErrorCode.ALREADY_FOLLOWED);
         }
 
@@ -53,71 +53,75 @@ public class FollowServiceImpl implements FollowService {
                 .build();
 
         followRepository.save(follow);
+
+        log.info("[Follow] 팔로우 성공: followerId={}, followingId={}", followerId, followingId);
     }
 
     // 언팔로우
     @Override
     @Transactional
-    public void unfollow(String followerUserEmail, Long followingId) {
+    public void unfollowUser(Long followerId, Long followingId) {
         // 유효성 검사 (null 또는 음수 체크)
         ValidationUtils.validateUserId(followingId);
 
-        // 팔로워 유저 조회
-        User follower = userService.findByEmail(followerUserEmail);
-        // 팔로이 유저 조회
-        User following = userService.findByUserId(followingId);
+        // 팔로워 유저 ID 검증
+        userService.verifyUserExists(followerId);
+        // 팔로이 유저 ID 검증
+        userService.verifyUserExists(followingId);
 
         // 팔로우 관계 조회 및 확인
-        Follow follow = getFollowRelationship(follower.getId(), followingId);
+        Follow follow = findFollowOrThrow(followerId, followingId);
 
         // 팔로우 관계 삭제
         followRepository.delete(follow);
+
+        log.info("[Follow] 언팔로우 성공: followerId={}, followingId={}", followerId, followingId);
     }
 
     // 나를 팔로우하고 있는 사용자 목록을 조회
     @Override
-    public List<FollowResponse> getFollowers(String email) {
+    public List<FollowResponse> getFollowers(Long userId) {
         // 사용자를 팔로우하는 사용자 목록을 조회
-        return getFollowList(email, false);
+        return getFollowList(userId, false);
     }
 
     // 내가 팔로우하고 있는 사용자 목록을 조회
     @Override
-    public List<FollowResponse> getFollowings(String email) {
+    public List<FollowResponse> getFollowings(Long userId) {
         // 팔로우 중인 사용자 목록을 조회
-        return getFollowList(email, true);
+        return getFollowList(userId, true);
     }
 
     /**
-     * 팔로우 목록 또는 팔로워 목록을 조회하고 FollowResponse 리스트로 변환하는 메서드
+     * 팔로우 또는 팔로워 목록 조회
      *
-     * @param email 현재 인증된 사용자 이메일
-     * @param isFollowings 팔로잉 목록인지 여부 (true: 팔로잉 목록, false: 팔로워 목록)
-     * @return FollowResponse 객체 리스트 반환
+     * @param userId 현재 사용자 ID
+     * @param isFollowings true: 팔로잉 목록, false: 팔로워 목록
+     * @return FollowResponse 리스트 반환
      */
-    private List<FollowResponse> getFollowList(String email, boolean isFollowings) {
+    private List<FollowResponse> getFollowList(Long userId, boolean isFollowings) {
         // 사용자 정보 조회
-        User user = userService.findByEmail(email);
+        User user = userService.findUserById(userId);
 
         // 팔로우 목록 또는 팔로워 목록을 조회
         List<Follow> followList = isFollowings
                 ? followRepository.findByFollower(user) // 팔로잉 목록 조회 (내가 팔로우하는 사람들)
                 : followRepository.findByFollowing(user); // 팔로워 목록 조회 (나를 팔로우하는 사람들)
 
-        // Follow 엔티티 리스트를 FollowUserDTO 리스트로 변환하여 반환
+        // Follow 엔티티 리스트를 FollowResponse 리스트로 변환하여 반환
         return followList.stream()
-                .map(follow -> convertToFollowResponse(follow, isFollowings, user.getId())) // DTO 변환
+                .map(follow -> convertToFollowResponse(follow, isFollowings, userId)) // DTO 변환
                 .sorted(Comparator.comparing(FollowResponse::getNickname)) // 닉네임 기준으로 정렬
                 .collect(Collectors.toList()); // 리스트로 수집하여 반환
     }
 
     /**
-     * Follow 엔티티를 FollowResponse로 변환하는 메서드
+     * Follow 엔티티를 FollowResponse DTO로 변환
      *
      * @param follow Follow 엔티티
-     * @param isFollowings 팔로우 목록인지 여부
-     * @param currentUserId 현재 인증된 사용자 ID
-     * @return FollowResponse 객체 반환
+     * @param isFollowings 팔로우 목록 여부
+     * @param currentUserId 현재 사용자 ID
+     * @return FollowResponse DTO
      */
     private FollowResponse convertToFollowResponse(Follow follow, boolean isFollowings, Long currentUserId) {
         // 타겟 유저를 결정: 팔로우 목록일 경우 수신자, 팔로워 목록일 경우 발신자
@@ -135,25 +139,24 @@ public class FollowServiceImpl implements FollowService {
                 .build();
     }
 
-    // 특정 사용자가 타켓 사용자를 팔로우하고 있는지 여부
+    // 특정 사용자가 대상 사용자를 팔로우하고 있는지 여부 확인
     @Override
-    public boolean isFollowing(Long userId, Long targetId) {
-        return followRepository.existsByFollowerIdAndFollowingId(userId, targetId);
+    public boolean isFollowing(Long followerId, Long followingId) {
+        return followRepository.existsByFollowerIdAndFollowingId(followerId, followingId);
     }
 
     /**
-     * 팔로우 관계를 조회하고 없을 경우 예외를 발생시킵니다.
+     * 팔로우 관계를 조회
      *
      * @param followerId 팔로우 요청자 ID
      * @param followingId 팔로우 대상자 ID
      * @return Follow 객체
      */
-    private Follow getFollowRelationship(Long followerId, Long followingId) {
+    private Follow findFollowOrThrow(Long followerId, Long followingId) {
         return followRepository.findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(() -> {
-                    log.warn("언팔로우 요청 실패: 팔로워 ID '{}'가 팔로이 ID '{}'를 팔로우하고 있지 않습니다.", followerId, followingId);
+                    log.warn("[Follow] 언팔로우 실패 (관계 없음): followerId={}, followingId={}", followerId, followingId);
                     return new CustomException(ErrorCode.NOT_FOLLOWING);
                 });
     }
-
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
@@ -20,7 +20,7 @@ public interface UserService {
     FollowResponse getUserDetail(String email, Long userId);
 
     // 유저 삭제
-    void deleteUser(String email, String deviceId, String refreshHeader);
+    void deleteUser(Long userId, String deviceId, String refreshHeader);
 
     /**
      * 이메일을 통해 사용자가 이미 등록되어 있는지 확인

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.tico.pomoro_do.domain.user.service;
 
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailResponse;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.global.exception.CustomException;
@@ -14,10 +14,10 @@ public interface UserService {
     User findUserByEmail(String email);
 
     // 내 프로필 조회
-    UserDetailResponse getMyProfile(Long userId);
+    UserDetailResponse getUserDetail(Long userId);
 
     // 특정 사용자 프로필 조회 (팔로우 상태 포함)
-    FollowResponse getUserProfile(Long currentUserId, Long targetUserId);
+    UserProfileResponse getUserProfile(Long currentUserId, Long targetUserId);
 
     // 사용자 삭제
     void deleteUser(Long userId, String deviceId, String refreshHeader);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserService.java
@@ -7,34 +7,40 @@ import com.tico.pomoro_do.global.exception.CustomException;
 
 public interface UserService {
 
-    // 사용자 아이디로 조회
-    User findByUserId(Long userId);
+    // 사용자 ID로 사용자 조회
+    User findUserById(Long userId);
 
-    // 사용자 이메일로 조회
-    User findByEmail(String email);
+    // 사용자 이메일로 사용자 조회
+    User findUserByEmail(String email);
 
-    // 내 정보 조회
-    UserDetailResponse getMyDetail(String email);
+    // 내 프로필 조회
+    UserDetailResponse getMyProfile(Long userId);
 
-    // 특정 사용자 정보 조회
-    FollowResponse getUserDetail(String email, Long userId);
+    // 특정 사용자 프로필 조회 (팔로우 상태 포함)
+    FollowResponse getUserProfile(Long currentUserId, Long targetUserId);
 
-    // 유저 삭제
+    // 사용자 삭제
     void deleteUser(Long userId, String deviceId, String refreshHeader);
 
     /**
-     * 이메일을 통해 사용자가 이미 등록되어 있는지 확인
-     *
-     * @param email 사용자 이메일
-     * @throws CustomException 이미 등록된 사용자인 경우 예외를 던짐
+     * 이메일이 중복되지 않았는지 검증
+     * @param email 검증할 이메일
+     * @throws CustomException 이메일이 이미 존재하는 경우 예외 발생
      */
-    void isEmailRegistered(String email);
+    void verifyEmailNotRegistered(String email);
 
     /**
-     * 이메일을 통해 사용자가 등록되어 있는지 검증
-     *
-     * @param email 사용자 이메일
-     * @throws CustomException 등록되지 않은 사용자일 경우 예외를 던짐
+     * 이메일이 존재하는지 검증
+     * @param email 검증할 이메일
+     * @throws CustomException 사용자를 찾을 수 없는 경우 예외 발생
      */
-    void validateEmailExists(String email);
+    void verifyEmailExists(String email);
+
+    /**
+     * 사용자 ID를 통해 등록된 사용자인지 검증
+     *
+     * @param userId 사용자 ID
+     * @throws CustomException 등록되지 않은 사용자일 경우 예외 발생
+     */
+    void verifyUserExists(Long userId);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
@@ -82,13 +82,13 @@ public class UserServiceImpl implements UserService{
 
     @Override
     @Transactional
-    public void deleteUser(String email, String deviceId, String refreshHeader) {
+    public void deleteUser(Long userId, String deviceId, String refreshHeader) {
         // 회원 토큰 검증
-        tokenService.validateRefreshTokenDetails(refreshHeader, deviceId, email);
+        tokenService.validateRefreshTokenDetails(refreshHeader, deviceId, userId);
         // 해당 회원의 모든 리프레시 토큰 삭제
-        tokenService.deleteAllRefreshTokensByEmail(email);
+        tokenService.deleteAllRefreshTokensByUserId(userId);
         // 해당 유저 삭제
-        userRepository.deleteByEmail(email);
+        userRepository.deleteById(userId);
     }
 
     // 이메일이 등록되어 있는 지 검증

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.tico.pomoro_do.domain.user.service;
 
 import com.tico.pomoro_do.domain.auth.service.TokenService;
-import com.tico.pomoro_do.domain.user.dto.response.FollowResponse;
+import com.tico.pomoro_do.domain.user.dto.response.UserProfileResponse;
 import com.tico.pomoro_do.domain.user.dto.response.UserDetailResponse;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.domain.user.repository.FollowRepository;
@@ -42,7 +42,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public UserDetailResponse getMyProfile(Long userId) {
+    public UserDetailResponse getUserDetail(Long userId) {
         User user = findUserById(userId);
         // 내가 팔로우하는 사람의 수 계산
         int followingCount = followRepository.countByFollower(user);
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public FollowResponse getUserProfile(Long currentUserId, Long targetUserId) {
+    public UserProfileResponse getUserProfile(Long currentUserId, Long targetUserId) {
 
         // 주어진 userId에 해당하는 특정 사용자 정보 조회
         User targetUser = findUserById(targetUserId);
@@ -72,7 +72,7 @@ public class UserServiceImpl implements UserService{
         log.info("[User] 특정 사용자 프로필 조회: currentUserId={}, targetUserId={}", currentUserId, targetUserId);
 
         // 사용자 정보 및 팔로우 상태를 포함한 DTO 반환
-        return FollowResponse.builder()
+        return UserProfileResponse.builder()
                 .userId(targetUser.getId())
                 .nickname(targetUser.getNickname())
                 .profileImageUrl(targetUser.getProfileImageUrl())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/UserServiceImpl.java
@@ -27,7 +27,7 @@ public class UserServiceImpl implements UserService{
     public User findByUserId(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> {
-                    log.error("사용자를 찾을 수 없음: {}", userId);
+                    log.error("등록되지 않은 사용자: 사용자ID = {}", userId);
                     return new CustomException(ErrorCode.USER_NOT_FOUND);
                 });
     }
@@ -36,7 +36,7 @@ public class UserServiceImpl implements UserService{
     public User findByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> {
-                    log.error("사용자를 찾을 수 없음: {}", email);
+                    log.error("등록되지 않은 사용자: 이메일 = {}", email);
                     return new CustomException(ErrorCode.USER_NOT_FOUND);
                 });
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTFilter.java
@@ -134,6 +134,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // 일시적인 세션 만들기
         // 토큰에서 사용자 정보 획득
+        Long userId = jwtUtil.getUserId(accessToken);
         String email = jwtUtil.getEmail(accessToken);
         String role = jwtUtil.getRole(accessToken);
 
@@ -154,6 +155,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // DTO로 사용자 정보 저장
         AuthUser authUser = AuthUser.builder()
+                .userId(userId)
                 .email(email)
                 .role(role)
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/JWTUtil.java
@@ -40,6 +40,10 @@ public class JWTUtil {
 //        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
 //    }
 
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
+    }
+
     // 유저 이메일 확인 메서드 -> JWT에서 사용자 이메일 추출
     public String getEmail(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
@@ -64,10 +68,11 @@ public class JWTUtil {
     }
 
     // 토큰 생성 메서드 (카테고리, 유저 이메일, 역할, 만료시간)
-    public String createJwt(String category, String email, String role, Long expiredMs) {
+    public String createJwt(String category, Long userId, String email, String role, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("category", category) //access인지? refesh인지?
+                .claim("userId", userId)
                 .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis())) // 생성 시각

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.global.auth.jwt;
 
+import com.tico.pomoro_do.domain.auth.security.CustomUserDetails;
 import com.tico.pomoro_do.domain.auth.service.TokenService;
 import com.tico.pomoro_do.global.enums.TokenType;
 import com.tico.pomoro_do.global.util.CookieUtil;
@@ -60,8 +61,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         log.info("Login success");
 
         //유저 정보
+
+        // CustomUserDetails로 캐스팅하여 userId 가져오기
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Long userId = userDetails.getUserId();
+
         //username 가져오기
         String username = authentication.getName();
+
         //role 가져오기 (동작)
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -70,8 +77,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = auth.getAuthority();
 
         //토큰 생성 (카테고리, 유저이름, 역할, 만료시간)
-        String access = jwtUtil.createJwt(TokenType.ACCESS.name(), username, role, accessExpiration); //60분
-        String refresh = jwtUtil.createJwt(TokenType.REFRESH.name(), username, role, refreshExpiration); //24시간
+        String access = jwtUtil.createJwt(TokenType.ACCESS.name(), userId, username, role, accessExpiration); //60분
+        String refresh = jwtUtil.createJwt(TokenType.REFRESH.name(), userId, username, role, refreshExpiration); //24시간
 
         //Refresh 토큰 저장
         String deviceId = request.getHeader("Device-ID");

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/auth/jwt/LoginFilter.java
@@ -82,7 +82,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         //Refresh 토큰 저장
         String deviceId = request.getHeader("Device-ID");
-        tokenService.createRefreshToken(username, refresh, refreshExpiration, deviceId);
+        tokenService.createRefreshToken(userId, refresh, refreshExpiration, deviceId);
 
         //응답 설정
         //access 토큰 헤더에 넣어서 응답 (key: value 형태) -> 예시) access: 인증토큰(string)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/code/ErrorCode.java
@@ -103,6 +103,8 @@ public enum ErrorCode {
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "U-105", "닉네임이 너무 깁니다. 최대 길이는 10자입니다."),
     USERNAME_MISMATCH(HttpStatus.BAD_REQUEST, "U-106", "현재 유저의 정보와 일치하지 않습니다."),
     USER_ID_INVALID(HttpStatus.BAD_REQUEST, "U-107", "USER ID가 비어있거나 유효하지 않습니다."),
+    USER_ID_MISMATCH(HttpStatus.BAD_REQUEST, "U-108", "현재 유저의 정보와 일치하지 않습니다."),
+
 
     //follow 관련 에러: -130번대
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "U-130", "본인은 팔로우할 수 없습니다."),

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/controller/RootController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/controller/RootController.java
@@ -1,6 +1,6 @@
 package com.tico.pomoro_do.global.controller;
 
-import com.tico.pomoro_do.global.response.AppInfoDTO;
+import com.tico.pomoro_do.global.response.AppInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +18,8 @@ public class RootController {
 
     @Operation(summary = "애플리케이션 기본 정보", description = "애플리케이션의 기본 정보를 제공합니다.")
     @GetMapping
-    public ResponseEntity<AppInfoDTO> getInfo() {
-        AppInfoDTO response = new AppInfoDTO(
+    public ResponseEntity<AppInfoResponse> getInfo() {
+        AppInfoResponse response = new AppInfoResponse(
                 "Pomoro-Do!",
                 "1.0.0",
                 "Pomoro-Do! 서비스에 오신 것을 환영합니다.",

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/AppInfoResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/AppInfoResponse.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class AppInfoDTO {
+public class AppInfoResponse {
     private String application;
     private String version;
     private String description;

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Schema(description = "Success Response")
-public class SuccessResponseDTO<T> {
+public class SuccessResponse<T> {
 
     @Schema(description = "상태 코드", nullable = false, example = "200")
     private final int status;       // 응답 코드 200번대
@@ -18,7 +18,7 @@ public class SuccessResponseDTO<T> {
     private final T data;           // 응답 데이터
 
     @Builder
-    public SuccessResponseDTO(int status, String message, T data) {
+    public SuccessResponse(int status, String message, T data) {
         this.status = status;
         this.message = message;
         this.data = data;


### PR DESCRIPTION
- AuthUser에 userId 필드 추가 및 JWT에 userId 포함
- customUserDetails에서 getUserId() 사용으로 인증 로직 변경
- Auth API와 User API의 인증 로직을 userId 기반으로 통합

Related to: TICO-164, TICO-205, TICO-370, TICO-372, TICO-378