### PR TITLE
[REFACTOR] 응답 객체에서 중복된 status 필드 제거 (TICO-377)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/auth/controller/AuthController.java
@@ -88,7 +88,6 @@ public class AuthController {
 
             // 성공 응답 생성
             SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
-                    .status(SuccessCode.GOOGLE_LOGIN_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_LOGIN_SUCCESS.getMessage())
                     .data(jwtResponse)
                     .build();
@@ -160,7 +159,6 @@ public class AuthController {
         try {
             TokenResponse jwtResponse = authService.googleJoin(googleIdTokenHeader, deviceId, nickname, profileImage, imageType);
             SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
-                    .status(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getHttpStatus().value())
                     .message(SuccessCode.GOOGLE_SIGNUP_SUCCESS.getMessage())
                     .data(jwtResponse)
                     .build();
@@ -212,7 +210,6 @@ public class AuthController {
         TokenResponse tokenResponse = authService.reissueToken(deviceId, refreshToken);
 
         SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
-                .status(SuccessCode.ACCESS_TOKEN_REISSUED.getHttpStatus().value())
                 .message(SuccessCode.ACCESS_TOKEN_REISSUED.getMessage())
                 .data(tokenResponse)
                 .build();
@@ -264,7 +261,6 @@ public class AuthController {
         tokenService.deleteRefreshTokenByDeviceId(deviceId);
 
         SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
-                .status(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.LOGOUT_SUCCESS.getMessage())
                 .data(SuccessCode.LOGOUT_SUCCESS.name()) // data가 없을 때는 null로 설정
                 .build();
@@ -301,7 +297,6 @@ public class AuthController {
         // 토큰 검증 후 SuccessCode 반환
         SuccessCode successCode = tokenService.validateTokenAndGetSuccessCode(tokenHeader, tokenType);;
         SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
-                .status(successCode.getHttpStatus().value())
                 .message(successCode.getMessage())
                 .data(successCode.name()) // data가 없을 때는 null로 설정
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
@@ -75,7 +75,6 @@ public class CategoryController {
         Long categoryId = categoryService.processCategoryCreation(userDetails.getUserId(), request);
 
         SuccessResponse<Long> successResponse = SuccessResponse.<Long>builder()
-                .status(SuccessCode.CATEGORY_CREATION_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_CREATION_SUCCESS.getMessage())
                 .data(categoryId)
                 .build();
@@ -119,7 +118,6 @@ public class CategoryController {
         UserCategoryResponse response = categoryService.getCategories(userDetails.getUserId(), type);
 
         SuccessResponse<UserCategoryResponse> successResponse = SuccessResponse.<UserCategoryResponse>builder()
-                .status(SuccessCode.CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(response)
                 .build();
@@ -161,7 +159,6 @@ public class CategoryController {
         List<CategoryInvitationResponse> response = categoryService.getCategoryInvitationsByStatus(userDetails.getUserId(), status);
 
         SuccessResponse<List<CategoryInvitationResponse>> successResponse = SuccessResponse.<List<CategoryInvitationResponse>>builder()
-                .status(SuccessCode.INVITED_CATEGORY_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.INVITED_CATEGORY_FETCH_SUCCESS.getMessage())
                 .data(response)
                 .build();
@@ -200,7 +197,6 @@ public class CategoryController {
         CategoryDetailResponse response = categoryService.getCategoryDetail(categoryId, userDetails.getUserId());
 
         SuccessResponse<CategoryDetailResponse> successResponse = SuccessResponse.<CategoryDetailResponse>builder()
-                .status(SuccessCode.CATEGORY_DETAIL_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.CATEGORY_DETAIL_FETCH_SUCCESS.getMessage())
                 .data(response)
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -56,7 +56,6 @@ public class AdminController {
 
         TokenResponse jwtResponse = adminService.adminJoin(request, profileImage);
         SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
-                .status(SuccessCode.ADMIN_SIGNUP_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
                 .data(jwtResponse)
                 .build();
@@ -88,7 +87,6 @@ public class AdminController {
         log.info("관리자 로그인 요청: {}", request.getEmail());
         TokenResponse jwtResponse = adminService.adminLogin(request);
         SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
-                .status(SuccessCode.ADMIN_LOGIN_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.ADMIN_LOGIN_SUCCESS.getMessage())
                 .data(jwtResponse)
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/FollowController.java
@@ -54,7 +54,6 @@ public class FollowController {
         Long currentUserId = customUserDetails.getUserId();
         followService.followUser(currentUserId, userId);
         SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
-                .status(SuccessCode.FOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOW_SUCCESS.getMessage())
                 .data(SuccessCode.FOLLOW_SUCCESS.name())
                 .build();
@@ -80,7 +79,6 @@ public class FollowController {
         Long currentUserId = customUserDetails.getUserId();
         followService.unfollowUser(currentUserId, userId);
         SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
-                .status(SuccessCode.UNFOLLOW_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.UNFOLLOW_SUCCESS.getMessage())
                 .data(SuccessCode.UNFOLLOW_SUCCESS.name())
                 .build();
@@ -111,7 +109,6 @@ public class FollowController {
         List<UserProfileResponse> followersList = followService.getFollowers(currentUserId);
 
         SuccessResponse<List<UserProfileResponse>> successResponse = SuccessResponse.<List<UserProfileResponse>>builder()
-                .status(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWERS_LIST_FETCH_SUCCESS.getMessage())
                 .data(followersList)
                 .build();
@@ -142,7 +139,6 @@ public class FollowController {
         List<UserProfileResponse> followingList = followService.getFollowings(currentUserId);
 
         SuccessResponse<List<UserProfileResponse>> successResponse = SuccessResponse.<List<UserProfileResponse>>builder()
-                .status(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.FOLLOWING_LIST_FETCH_SUCCESS.getMessage())
                 .data(followingList)
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/ImageController.java
@@ -56,7 +56,6 @@ public class ImageController {
                 .build();
 
         SuccessResponse<ImageResponse> response = SuccessResponse.<ImageResponse>builder()
-                .status(SuccessCode.IMAGE_UPLOAD_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.IMAGE_UPLOAD_SUCCESS.getMessage())
                 .data(imageResponse)
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/UserController.java
@@ -41,7 +41,6 @@ public class UserController {
 
         UserDetailResponse userDetailResponse = userService.getUserDetail(customUserDetails.getUserId());
         SuccessResponse<UserDetailResponse> successResponse = SuccessResponse.<UserDetailResponse>builder()
-                .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
                 .data(userDetailResponse)
                 .build();
@@ -69,7 +68,6 @@ public class UserController {
     ) {
         UserProfileResponse response = userService.getUserProfile(customUserDetails.getUserId(), userId);
         SuccessResponse<UserProfileResponse> successResponse = SuccessResponse.<UserProfileResponse>builder()
-                .status(SuccessCode.USER_FETCH_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_FETCH_SUCCESS.getMessage())
                 .data(response)
                 .build();
@@ -95,7 +93,6 @@ public class UserController {
         userService.deleteUser(customUserDetails.getUserId(), deviceId, refreshToken);
 
         SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
-                .status(SuccessCode.USER_DELETION_SUCCESS.getHttpStatus().value())
                 .message(SuccessCode.USER_DELETION_SUCCESS.getMessage())
                 .data(SuccessCode.USER_DELETION_SUCCESS.name())
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/CustomException.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/CustomException.java
@@ -15,6 +15,5 @@ public class CustomException extends RuntimeException{
     //ErrorCode를 담을 class 생성한다.
     //RuntimeException 상속
     //Custom Error Code 속성 추가
-
     ErrorCode errorCode;
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorResponseEntity.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorResponseEntity.java
@@ -16,13 +16,13 @@ import org.springframework.http.ResponseEntity;
 public class ErrorResponseEntity {
     //Custom Error 내용을 담을 Response Entity를 생성한다.
 
-    @Schema(description = "HTTP 상태 코드")
-    private int status;
+//    @Schema(description = "HTTP 상태 코드")
+//    private int status;
 //    @Schema(description = "에러 이름")
 //    private String name;
-    @Schema(description = "커스텀 에러 코드")
+    @Schema(description = "커스텀 에러 코드", example = "U-100")
     private String code;
-    @Schema(description = "에러 메시지")
+    @Schema(description = "에러 메시지", example = "이미 사용 중인 이메일입니다.")
     private String message;
 
 
@@ -30,7 +30,7 @@ public class ErrorResponseEntity {
         return ResponseEntity
                 .status(e.getHttpStatus())
                 .body(ErrorResponseEntity.builder()
-                        .status(e.getHttpStatus().value())
+//                        .status(e.getHttpStatus().value())
 //                        .name(e.name())
                         .code(e.getCode())
                         .message(e.getMessage())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/GlobalExceptionHandler.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/GlobalExceptionHandler.java
@@ -75,7 +75,7 @@ public class GlobalExceptionHandler {
         }
 
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.VALIDATION_FAILED.getCode())
                 .message("Validation failed for fields: " + errors.toString())
                 .build();
@@ -94,7 +94,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
         log.error("MissingRequestHeaderException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.MISSING_REQUEST_HEADER.getCode())
                 .message("Required request header is missing: " + ex.getHeaderName())
                 .build();
@@ -114,7 +114,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
         log.error("HttpMessageNotReadableException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.MISSING_REQUEST_BODY.getCode())
                 .message("Required request body is missing or unreadable.")
                 .build();
@@ -133,7 +133,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
         log.error("MissingServletRequestParameterException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.MISSING_REQUEST_PARAMETER.getCode())
                 .message("Required request parameter is missing: " + ex.getParameterName())
                 .build();
@@ -152,7 +152,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleBadRequestException(HttpClientErrorException e) {
         log.error("HttpClientErrorException.BadRequest: ", e);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.BAD_REQUEST.getCode())
                 .message("Required request is missing. Bad request: " + e.getMessage())
                 .build();
@@ -177,7 +177,7 @@ public class GlobalExceptionHandler {
         String message = String.format("Parameter '%s' should be of type '%s'.", parameterName, parameterType);
 
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.INVALID_PARAMETER_TYPE.getCode())
                 .message(message)
                 .build();
@@ -196,7 +196,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleIllegalArgumentException(IllegalArgumentException ex) {
         log.error("IllegalArgumentException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.INVALID_TYPE_VALUE.getCode())
                 .message("Invalid argument: " + ex.getMessage())
                 .build();
@@ -215,7 +215,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleIOException(IOException ex) {
         log.error("IOException occurred: {}", ex.getMessage(), ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.IO_ERROR.getCode())
                 .message("I/O error occurred: " + ex.getMessage())
                 .build();
@@ -234,7 +234,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleJsonParseException(JsonParseException ex) {
         log.error("JsonParseException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.JSON_PARSE_ERROR.getCode())
                 .message("Failed to parse JSON: " + ex.getMessage())
                 .build();
@@ -253,7 +253,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleJsonProcessingException(JsonProcessingException ex) {
         log.error("JsonProcessingException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.JSON_PROCESSING_ERROR.getCode())
                 .message("Failed to process JSON: " + ex.getMessage())
                 .build();
@@ -272,7 +272,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleJsonMappingException(JsonMappingException ex) {
         log.error("JsonMappingException occurred: {}", ex.getMessage(), ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.JSON_MAPPING_ERROR.getCode())
                 .message("Failed to map JSON: " + ex.getMessage())
                 .build();
@@ -291,7 +291,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMultipartException(MultipartException ex) {
         log.error("MultipartException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.INVALID_MULTIPART_DATA.getCode())
                 .message("Failed to process multipart request: " + ex.getMessage())
                 .build();
@@ -310,7 +310,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
         log.error("MaxUploadSizeExceededException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED.getCode())
                 .message("The uploaded file exceeds the allowed maximum size. Please upload a file within the allowed size.")                .build();
 
@@ -329,7 +329,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMissingRequestCookieException(MissingRequestCookieException ex) {
         log.error("MissingRequestCookieException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
+//                .status(HttpStatus.BAD_REQUEST.value())
                 .code(ErrorCode.INVALID_COOKIE.getCode())
                 .message("Required cookie is missing.")
                 .build();
@@ -348,7 +348,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleForbiddenException(HttpClientErrorException.Forbidden ex) {
         log.error("HttpClientErrorException.Forbidden: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.FORBIDDEN.value())
+//                .status(HttpStatus.FORBIDDEN.value())
                 .code(ErrorCode.FORBIDDEN.getCode())
                 .message("Forbidden: " + ex.getMessage())
                 .build();
@@ -367,7 +367,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleAccessDeniedException(AccessDeniedException ex) {
         log.error("AccessDeniedException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.FORBIDDEN.value())
+//                .status(HttpStatus.FORBIDDEN.value())
                 .code(ErrorCode.ACCESS_DENIED.getCode())
                 .message("Access Denied: " + ex.getMessage())
                 .build();
@@ -386,7 +386,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleEntityNotFoundException(EntityNotFoundException ex) {
         log.error("EntityNotFoundException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.NOT_FOUND.value())
+//                .status(HttpStatus.NOT_FOUND.value())
                 .code(ErrorCode.ENTITY_NOT_FOUND.getCode())
                 .message("Entity Not Found: " + ex.getMessage())
                 .build();
@@ -406,7 +406,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleNoHandlerFoundException(NoHandlerFoundException ex) {
         log.error("NoHandlerFoundException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.NOT_FOUND.value())
+//                .status(HttpStatus.NOT_FOUND.value())
                 .code(ErrorCode.NO_HANDLER_FOUND.getCode())
                 .message("No handler found for the requested URL [" + ex.getRequestURL() + "]. Please ensure the URL is correct.")
                 .build();
@@ -426,7 +426,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleNoResourceFoundException(NoResourceFoundException ex) {
         log.error("NoResourceFoundException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.NOT_FOUND.value())
+//                .status(HttpStatus.NOT_FOUND.value())
                 .code(ErrorCode.NO_RESOURCE_FOUND.getCode())
                 .message(ex.getMessage())
                 .build();
@@ -445,7 +445,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleNoSuchElementException(NoSuchElementException ex) {
         log.error("NoSuchElementException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.NOT_FOUND.value())
+//                .status(HttpStatus.NOT_FOUND.value())
                 .code(ErrorCode.NOT_FOUND.getCode())
                 .message("The requested resource was not found.")
                 .build();
@@ -465,7 +465,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleAuthenticationException(AuthenticationException ex) {
         log.error("AuthenticationException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.UNAUTHORIZED.value())
+//                .status(HttpStatus.UNAUTHORIZED.value())
                 .code(ErrorCode.UNAUTHORIZED.getCode())
                 .message(ex.getMessage())
                 .build();
@@ -484,7 +484,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleSignatureException(SignatureException ex) {
         log.error("SignatureException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.UNAUTHORIZED.value())
+//                .status(HttpStatus.UNAUTHORIZED.value())
                 .code(ErrorCode.INVALID_JWT_SIGNATURE.getCode())
                 .message("JWT signature verification failed.")
                 .build();
@@ -503,7 +503,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleMalformedJwtException(MalformedJwtException ex) {
         log.error("MalformedJwtException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.UNAUTHORIZED.value())
+//                .status(HttpStatus.UNAUTHORIZED.value())
                 .code(ErrorCode.INVALID_MALFORMED_JWT.getCode())
                 .message("Malformed JWT token.")
                 .build();
@@ -522,7 +522,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
         log.error("HttpRequestMethodNotSupportedException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.METHOD_NOT_ALLOWED.value())
+//                .status(HttpStatus.METHOD_NOT_ALLOWED.value())
                 .code(ErrorCode.METHOD_NOT_ALLOWED.getCode())
                 .message("Method Not Allowed: " + ex.getMethod())
                 .build();
@@ -542,7 +542,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleNullPointerException(NullPointerException ex) {
         log.error("NullPointerException: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+//                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .code(ErrorCode.NULL_POINTER.getCode())
                 .message("A null pointer exception occurred.")
                 .build();
@@ -562,7 +562,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseEntity> handleException(Exception ex) {
         log.error("Exception: ", ex);
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+//                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .code(ErrorCode.INTERNAL_SERVER_ERROR.getCode())
                 .message("An unexpected error occurred: " + ex.getMessage())
                 .build();

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessResponse.java
@@ -8,18 +8,18 @@ import lombok.Getter;
 @Schema(description = "Success Response")
 public class SuccessResponse<T> {
 
-    @Schema(description = "상태 코드", nullable = false, example = "200")
-    private final int status;       // 응답 코드 200번대
+//    @Schema(description = "상태 코드", nullable = false, example = "200")
+//    private final int status;       // 응답 코드 200번대
     @Schema(description = "성공 코드", nullable = false, example = "SUCCESS")
     private final String code = "SUCCESS";
     @Schema(description = "상태 메세지", nullable = false, example = "요청이 성공적으로 처리되었습니다.")
     private final String message;   // 메시지
-    @Schema(description = "해당 API의 응답 데이터", nullable = true)
+    @Schema(description = "응답 데이터", nullable = true)
     private final T data;           // 응답 데이터
 
     @Builder
-    public SuccessResponse(int status, String message, T data) {
-        this.status = status;
+    public SuccessResponse(String message, T data) {
+//        this.status = status;
         this.message = message;
         this.data = data;
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/security/filter/JwtFilter.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/security/filter/JwtFilter.java
@@ -179,7 +179,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // response body
         ErrorResponseEntity errorResponse = ErrorResponseEntity.builder()
-                .status(errorCode.getHttpStatus().value())
+//                .status(errorCode.getHttpStatus().value())
                 .code(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();


### PR DESCRIPTION
HTTP 상태 코드는 헤더에 포함되므로 에러 및 성공 응답 내부의 status 필드 제거

Related to: TICO-205