### PR TITLE
[FEAT] 카테고리 초대 응답 API 구현 (TICO-336)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.domain.category.controller;
 
+import com.tico.pomoro_do.domain.category.dto.request.CategoryInvitationDecisionRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryInvitationResponse;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
 import com.tico.pomoro_do.domain.category.service.CategoryInvitationService;
@@ -14,10 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -69,5 +67,21 @@ public class CategoryInvitationController {
                 .data(response)
                 .build();
         return ResponseEntity.ok(successResponse);
+    }
+
+    @PatchMapping("/{invitationId}")
+    public ResponseEntity<SuccessResponse<String>> responseInvitation(
+            @PathVariable Long invitationId,
+            @RequestBody CategoryInvitationDecisionRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails // 로그인 유저
+    ) {
+        categoryInvitationService.respondInvitation(invitationId, userDetails.getUserId(), request);
+
+        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
+                .message(SuccessCode.CATEGORY_INVITATION_RESPONSE_SUCCESS.getMessage())
+                .data(SuccessCode.CATEGORY_INVITATION_RESPONSE_SUCCESS.name())
+                .build();
+        return ResponseEntity.ok(successResponse);
+
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
@@ -69,6 +69,36 @@ public class CategoryInvitationController {
         return ResponseEntity.ok(successResponse);
     }
 
+    /**
+     * 카테고리 초대장 응답 API
+     *
+     * @param invitationId 응답할 초대장 ID
+     * @param request 사용자 응답 정보 (ACCEPTED or REJECTED)
+     * @param userDetails 인증된 사용자 정보
+     * @return 응답 성공 메시지
+     */
+    @Operation(
+            summary = "카테고리 초대 응답",
+            description = """
+                    사용자가 받은 그룹 초대장에 수락 또는 거절로 응답합니다.
+            
+                    ## 요청 값
+                    - `ACCEPTED`: 초대를 수락하고 그룹에 참여
+                    - `REJECTED`: 초대를 거절하고 무시
+            
+                    ## 응답 처리
+                    - 이미 응답한 초대는 처리할 수 없습니다.
+                    - 수락 시 자동으로 그룹 멤버로 등록됩니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초대 응답 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 중복 응답"),
+            @ApiResponse(responseCode = "401", description = "인증 오류 - 로그인 필요"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 - 본인의 초대가 아님"),
+            @ApiResponse(responseCode = "404", description = "초대장이 존재하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     @PatchMapping("/{invitationId}")
     public ResponseEntity<SuccessResponse<String>> responseInvitation(
             @PathVariable Long invitationId,
@@ -82,6 +112,5 @@ public class CategoryInvitationController {
                 .data(SuccessCode.CATEGORY_INVITATION_RESPONSE_SUCCESS.name())
                 .build();
         return ResponseEntity.ok(successResponse);
-
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/request/CategoryInvitationDecisionRequest.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/request/CategoryInvitationDecisionRequest.java
@@ -10,5 +10,6 @@ import lombok.Getter;
 public class CategoryInvitationDecisionRequest {
 
     @NotNull(message = "초대 응답은 필수입니다.")
-    private CategoryInvitationDecision decision; // ACCEPTED or REJECTED
+    @Schema(description = "카테고리 초대 응답 유형 (ACCEPTED/REJECTED)", example = "ACCEPTED")
+    private CategoryInvitationDecision decision;
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/request/CategoryInvitationDecisionRequest.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/request/CategoryInvitationDecisionRequest.java
@@ -1,0 +1,14 @@
+package com.tico.pomoro_do.domain.category.dto.request;
+
+import com.tico.pomoro_do.domain.category.enums.CategoryInvitationDecision;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "카테고리 초대 응답 요청")
+public class CategoryInvitationDecisionRequest {
+
+    @NotNull(message = "초대 응답은 필수입니다.")
+    private CategoryInvitationDecision decision; // ACCEPTED or REJECTED
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/entity/CategoryInvitation.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/entity/CategoryInvitation.java
@@ -3,6 +3,8 @@ package com.tico.pomoro_do.domain.category.entity;
 import com.tico.pomoro_do.domain.user.entity.User;
 import com.tico.pomoro_do.global.common.entity.BaseTimeEntity;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
+import com.tico.pomoro_do.global.exception.CustomException;
+import com.tico.pomoro_do.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,9 +48,13 @@ public class CategoryInvitation extends BaseTimeEntity {
     /**
      * 초대 상태 업데이트 메소드
      *
-     * @param status 변경할 상태
+     * @param decision 변경할 상태
      */
-    public void updateStatus(CategoryInvitationStatus status) {
-        this.status = status;
+    public void respondToInvitation(CategoryInvitationStatus decision) {
+        // 초대 중복 응답 방지
+        if (this.status != CategoryInvitationStatus.PENDING) {
+            throw new CustomException(ErrorCode.INVITATION_ALREADY_RESPONDED);
+        }
+        this.status = decision;
     }
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/enums/CategoryInvitationDecision.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/enums/CategoryInvitationDecision.java
@@ -1,0 +1,6 @@
+package com.tico.pomoro_do.domain.category.enums;
+
+public enum CategoryInvitationDecision {
+    ACCEPTED,
+    REJECTED
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
@@ -1,5 +1,6 @@
 package com.tico.pomoro_do.domain.category.service;
 
+import com.tico.pomoro_do.domain.category.dto.request.CategoryInvitationDecisionRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryInvitationResponse;
 import com.tico.pomoro_do.domain.category.entity.Category;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
@@ -55,4 +56,6 @@ public interface CategoryInvitationService {
      * @return 초대장 응답 DTO 리스트
      */
     List<CategoryInvitationResponse> findInvitationsByStatus(User user, CategoryInvitationStatus status);
+
+    void respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
@@ -57,5 +57,14 @@ public interface CategoryInvitationService {
      */
     List<CategoryInvitationResponse> findInvitationsByStatus(User user, CategoryInvitationStatus status);
 
+    /**
+     * 초대장에 대한 응답 처리 (수락 또는 거절)
+     * - 초대장 존재 여부와 응답 권한을 검증합니다.
+     * - 수락 시 그룹 멤버로 자동 등록됩니다.
+     *
+     * @param invitationId 응답할 초대장 ID
+     * @param userId 응답하는 사용자 ID
+     * @param request 응답 요청 객체 (ACCEPTED 또는 REJECTED)
+     */
     void respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationServiceImpl.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true) // 조회 기본 설정
 @Slf4j
 public class CategoryInvitationServiceImpl implements CategoryInvitationService{
 
@@ -212,41 +212,74 @@ public class CategoryInvitationServiceImpl implements CategoryInvitationService{
         );
     }
 
+    /**
+     * 초대장에 대한 응답 처리 (수락 or 거절)
+     * - 초대장 존재 여부 확인
+     * - 응답 사용자의 권한 검증
+     * - 초대장 상태 변경
+     * - 수락 시 그룹 멤버로 등록
+     *
+     * @param invitationId 응답할 초대장 ID
+     * @param userId 현재 로그인한 사용자 ID
+     * @param request 응답 요청 (수락/거절)
+     */
     @Override
     @Transactional
     public void respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request) {
+        // 1. 초대장 조회
         CategoryInvitation invitation = getInvitationById(invitationId);
+        // 2. 초대 대상자 본인인지 확인
         validateInvitee(invitation, userId);
 
-        // 요청용 Enum → 상태 Enum 매핑
+        // 3. 요청 값(ACCEPTED/REJECTED)을 도메인 상태로 변환
         CategoryInvitationStatus status = switch (request.getDecision()) {
             case ACCEPTED -> CategoryInvitationStatus.ACCEPTED;
             case REJECTED -> CategoryInvitationStatus.REJECTED;
         };
 
-        // 도메인에서 상태 변경
+        // 4. 상태 변경 (엔티티 내부에서 상태값 변경)
         invitation.respondToInvitation(status);
 
-        // 초대 승낙이면 그룹 멤버 생성
+        // 5. 수락한 경우 그룹 멤버로 등록
         if (status == CategoryInvitationStatus.ACCEPTED) {
             categoryMemberService.createCategoryMember(
                     invitation.getCategory(),
                     invitation.getInvitee(),
                     CategoryMemberRole.MEMBER
             );
+            log.info("초대 수락: 그룹 멤버 생성 완료 - categoryId={}, userId={}",
+                    invitation.getCategory().getId(), invitation.getInvitee().getId());
         }
     }
 
+    /**
+     * 초대장 ID로 초대 정보를 조회합니다.
+     * 존재하지 않는 경우 예외를 발생시킵니다.
+     *
+     * @param invitationId 초대장 ID
+     * @return CategoryInvitation 객체
+     * @throws CustomException 초대장이 존재하지 않을 경우
+     */
     private CategoryInvitation getInvitationById(Long invitationId) {
-        // 초대 정보 가져오기
         return categoryInvitationRepository.findById(invitationId)
-                .orElseThrow(() -> new CustomException(ErrorCode.INVITATION_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("초대장 조회 실패: 존재하지 않음 - invitationId={}", invitationId);
+                    return new CustomException(ErrorCode.INVITATION_NOT_FOUND);
+                });
     }
 
-    // 초대 받은 사람 맞는 지 확인
+    /**
+     * 응답 사용자가 실제 초대 대상자인지 검증합니다.
+     *
+     * @param invitation 초대장
+     * @param userId 응답자 ID
+     * @throws CustomException 본인이 아닌 경우
+     */
     private void validateInvitee(CategoryInvitation invitation, Long userId) {
-        // 응답 대상자인지 확인
-        if (!invitation.getInvitee().getId().equals(userId)) {
+        Long inviteeId = invitation.getInvitee().getId();
+        if (!inviteeId.equals(userId)) {
+            log.warn("초대 대상자 불일치: invitationId={}, expectedInviteeId={}, actualUserId={}",
+                    invitation.getId(), inviteeId, userId);
             throw new CustomException(ErrorCode.NOT_INVITEE);
         }
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorCode.java
@@ -168,7 +168,7 @@ public enum ErrorCode {
     CATEGORY_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C-605", "카테고리 삭제 중 오류가 발생했습니다."),
     CATEGORY_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C-606", "카테고리 업데이트 중 오류가 발생했습니다."),
     CATEGORY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "C-607", "그룹 카테고리의 멤버를 찾을 수 없습니다."),
-    CATEGORY_MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "C-608", "해당 멤버는 이미 그룹에 포함되어 있습니다."),
+    CATEGORY_MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "C-608", "이미 그룹에 가입된 사용자입니다."),
     CATEGORY_MEMBER_ADDITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C-609", "그룹 카테고리에 멤버 추가 중 오류가 발생했습니다."),
     CATEGORY_MEMBER_REMOVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "C-610", "그룹 카테고리에서 멤버 삭제 중 오류가 발생했습니다."),
     CATEGORY_MEMBER_NOT_FOLLOWED(HttpStatus.BAD_REQUEST, "C-611", "팔로우하지 않은 사용자는 그룹에 초대할 수 없습니다."),
@@ -179,14 +179,14 @@ public enum ErrorCode {
     INVALID_CATEGORY_VISIBILITY(HttpStatus.BAD_REQUEST, "C-623", "유효하지 않은 카테고리 공개 범위입니다."),
 //    OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "C-618", "카테고리 관리자는 탈퇴할 수 없습니다."),
 
-    // 초대 관련 에러: -650번대
-    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "C-651", "초대장을 찾을 수 없습니다."),
-    DUPLICATE_INVITATION(HttpStatus.BAD_REQUEST, "C-652", "이미 초대된 사용자입니다."),
-    INVALID_INVITATION_STATUS(HttpStatus.BAD_REQUEST, "C-653", "유효하지 않은 초대 상태입니다."),
-    ALREADY_CATEGORY_MEMBER(HttpStatus.BAD_REQUEST, "C-654", "이미 카테고리 멤버인 사용자입니다."),
-
+    // 초대 응답 관련 에러: -650번대,
+    INVALID_INVITATION_STATUS(HttpStatus.BAD_REQUEST, "CI-650", "유효하지 않은 초대 상태입니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-651", "해당 초대 정보를 찾을 수 없습니다."),
+    DUPLICATE_INVITATION(HttpStatus.BAD_REQUEST, "CI-652", "이미 초대된 사용자입니다."),
+    INVITATION_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "CI-653", "이미 응답한 초대입니다."),
+    ALREADY_CATEGORY_MEMBER(HttpStatus.BAD_REQUEST, "CI-654", "이미 카테고리 멤버인 사용자입니다."),
+    NOT_INVITEE(HttpStatus.FORBIDDEN, "CI-655", "해당 초대에 응답할 권한이 없습니다."),
     ;
-
 
     private final HttpStatus httpStatus;	// HttpStatus
     private final String code;				// U-100

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/response/SuccessCode.java
@@ -38,12 +38,18 @@ public enum SuccessCode {
     CATEGORY_DELETION_SUCCESS(HttpStatus.OK, "카테고리 삭제에 성공했습니다."),
     CATEGORY_UPDATE_SUCCESS(HttpStatus.OK, "카테고리 업데이트에 성공했습니다."),
     CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "카테고리 조회에 성공했습니다."),
-    GENERAL_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "일반 카테고리 조회에 성공했습니다."),
-    GROUP_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "그룹 카테고리 조회에 성공했습니다."),
-    INVITED_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "초대받은 카테고리 조회에 성공했습니다."),
     CATEGORY_DETAIL_FETCH_SUCCESS(HttpStatus.OK, "카테고리 상세 정보 조회에 성공했습니다."),
+
+    GENERAL_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "일반 카테고리 조회에 성공했습니다."),
+
+    GROUP_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "그룹 카테고리 조회에 성공했습니다."),
     CATEGORY_MEMBER_ADDITION_SUCCESS(HttpStatus.OK, "그룹 카테고리에 멤버 추가에 성공했습니다."),
     CATEGORY_MEMBER_REMOVAL_SUCCESS(HttpStatus.OK, "그룹 카테고리에서 멤버 삭제에 성공했습니다."),
+
+    INVITED_CATEGORY_FETCH_SUCCESS(HttpStatus.OK, "초대받은 카테고리 조회에 성공했습니다."),
+    CATEGORY_INVITATION_RESPONSE_SUCCESS(HttpStatus.OK, "카테고리 초대에 응답하였습니다."),
+    CATEGORY_INVITATION_ACCEPT_SUCCESS(HttpStatus.OK, "카테고리 초대를 수락하였습니다."),
+    CATEGORY_INVITATION_REJECT_SUCCESS(HttpStatus.OK, "카테고리 초대를 거절하였습니다."),
 
     ;
 


### PR DESCRIPTION
- 응답 요청 처리 및 상태 매핑(Enum 분리)
- 도메인 메서드로 상태 전이 위임
- 수락 시 중복 검사 후 멤버 등록


Related to: TICO-255