### PR TITLE
[CHORE] 그룹장의 그룹원 ui 변경(TICO-416)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -77,7 +77,6 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 navigateToBack = navController::popBackStack
             )
             infoCategoryScreen(
-                navigateToGroupMemberChoose = navController::navigateToGroupMemberChoose,
                 navigateToBack = navController::popBackStack
             )
             groupMemberChooseScreen(

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -237,7 +237,6 @@ internal class CategoryArgs(savedStateHandle: SavedStateHandle) {
 }
 
 fun NavGraphBuilder.infoCategoryScreen(
-    navigateToGroupMemberChoose: (String) -> Unit,
     navigateToBack: () -> Unit
 ) {
     composable(
@@ -246,7 +245,6 @@ fun NavGraphBuilder.infoCategoryScreen(
     ) {
         CategoryInfoScreenRoute(
             navigateToBack = navigateToBack,
-            navigateToGroupMemberChoose = navigateToGroupMemberChoose
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -32,7 +32,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.tico.pomorodo.R
 import com.tico.pomorodo.data.model.CategoryType
 import com.tico.pomorodo.data.model.OpenSettings
-import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.ui.category.viewModel.CategoryInfoViewModel
 import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTextField
@@ -50,7 +49,6 @@ import kotlinx.coroutines.launch
 fun CategoryInfoScreenRoute(
     viewModel: CategoryInfoViewModel = hiltViewModel(),
     navigateToBack: () -> Unit,
-    navigateToGroupMemberChoose: (String) -> Unit,
 ) {
     val openSettingsOptionSheetState = rememberModalBottomSheetState()
     val checkGroupMemberSheetState = rememberModalBottomSheetState()
@@ -181,11 +179,6 @@ fun CategoryInfoScreenRoute(
                     onShowOpenSettingsBottomSheetChange = {
                         showOpenSettingsBottomSheet = it
                     },
-                    onGroupMemberChooseClicked = {
-                        navigateToGroupMemberChoose(
-                            MainNavigationDestination.INFO_CATEGORY.name
-                        )
-                    },
                     onShowCheckGroupMemberBottomSheetChange = {
                         showCheckGroupMemberBottomSheet = it
                     },
@@ -209,7 +202,6 @@ fun CategoryInfoScreen(
     groupReader: String? = null,
     isGroupReader: Boolean?,
     onShowOpenSettingsBottomSheetChange: (Boolean) -> Unit,
-    onGroupMemberChooseClicked: () -> Unit,
     onShowCheckGroupMemberBottomSheetChange: (Boolean) -> Unit,
     onGroupOutClicked: () -> Unit,
     onGroupDeleteClicked: () -> Unit,
@@ -278,11 +270,7 @@ fun CategoryInfoScreen(
                 CategoryGroupNumber(
                     groupMemberCount = groupMemberCount,
                     onClicked = {
-                        if (isGroupReader == true) {
-                            onGroupMemberChooseClicked()
-                        } else if (isGroupReader == false) {
-                            onShowCheckGroupMemberBottomSheetChange(true)
-                        }
+                        onShowCheckGroupMemberBottomSheetChange(true)
                     },
                     isGroupReader = isGroupReader
                 )


### PR DESCRIPTION
변경 사항

그룹장일 경우 “카테고리 정보 / 설정”에서 그룹원을 클릭 시, 그룹원 편집 페이지가 아닌 그룹원 정보 바텀 시트 표시로 수정


Fixes: TICO-416