### PR TITLE
[CHORE] 카테고리 정보/설정 UI 일부 수정 및 종료 다이얼로그 추가(TICO-429)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
@@ -1,5 +1,6 @@
 package com.tico.pomorodo.ui.category.view
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -280,6 +282,8 @@ fun CategoryAddScreenRoute(
 ) {
     val openSettingsOptionSheetState = rememberModalBottomSheetState()
     var showOpenSettingsBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var endOfWritingDialogVisible by remember { mutableStateOf(false) }
+
     val scope = rememberCoroutineScope()
 
     val title by viewModel.title.collectAsState()
@@ -289,7 +293,9 @@ fun CategoryAddScreenRoute(
 
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
-
+    BackHandler {
+        endOfWritingDialogVisible = true
+    }
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -313,7 +319,9 @@ fun CategoryAddScreenRoute(
                     viewModel.insertCategory()
                     navigateToBack()
                 },
-                onBackClickedListener = navigateToBack,
+                onBackClickedListener = {
+                    endOfWritingDialogVisible = true
+                },
                 isActionEnabled = viewModel.validateInput()
             )
             if (showOpenSettingsBottomSheet) {
@@ -330,6 +338,15 @@ fun CategoryAddScreenRoute(
                                     showOpenSettingsBottomSheet = false
                                 }
                             }
+                    }
+                )
+            }
+            if (endOfWritingDialogVisible) {
+                EndOfWritingDialog(
+                    onDismissRequest = { endOfWritingDialogVisible = false },
+                    onConfirmation = {
+                        endOfWritingDialogVisible = false
+                        navigateToBack()
                     }
                 )
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
@@ -43,7 +43,6 @@ import com.tico.pomorodo.ui.common.view.SimpleIcon
 import com.tico.pomorodo.ui.common.view.SimpleText
 import com.tico.pomorodo.ui.common.view.addFocusCleaner
 import com.tico.pomorodo.ui.common.view.clickableWithoutRipple
-import com.tico.pomorodo.ui.theme.IC_ARROW_RIGHT
 import com.tico.pomorodo.ui.theme.IC_CATEGORY_FOLLOWER_OPEN
 import com.tico.pomorodo.ui.theme.IC_DROP_DOWN
 import com.tico.pomorodo.ui.theme.IC_DROP_DOWN_DISABLE
@@ -126,7 +125,10 @@ fun CategoryAddScreen(
 }
 
 @Composable
-fun CategoryGroupNumber(groupMemberCount: Int, onClicked: () -> Unit, isGroupReader: Boolean? = true) {
+fun CategoryGroupNumber(
+    groupMemberCount: Int,
+    onClicked: () -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -134,7 +136,7 @@ fun CategoryGroupNumber(groupMemberCount: Int, onClicked: () -> Unit, isGroupRea
     ) {
         SimpleText(
             textId = R.string.content_group_member,
-            style = PomoroDoTheme.typography.laundryGothicRegular14,
+            style = PomoroDoTheme.typography.laundryGothicBold14,
             color = PomoroDoTheme.colorScheme.onBackground
         )
         Spacer(modifier = Modifier.weight(1f))
@@ -155,8 +157,7 @@ fun CategoryGroupNumber(groupMemberCount: Int, onClicked: () -> Unit, isGroupRea
             )
             SimpleIcon(
                 size = 15,
-                imageVector = if (isGroupReader == true) requireNotNull(PomoroDoTheme.iconPack[IC_ARROW_RIGHT])
-                else requireNotNull(PomoroDoTheme.iconPack[IC_DROP_DOWN]),
+                imageVector = requireNotNull(PomoroDoTheme.iconPack[IC_DROP_DOWN]),
                 contentDescriptionId = R.string.content_full_open
             )
         }
@@ -179,7 +180,7 @@ fun CategoryOpenSettings(
     ) {
         SimpleText(
             textId = R.string.title_open_settings,
-            style = PomoroDoTheme.typography.laundryGothicRegular14,
+            style = PomoroDoTheme.typography.laundryGothicBold14,
             color = PomoroDoTheme.colorScheme.onBackground
         )
         Spacer(modifier = Modifier.weight(1f))

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -315,8 +315,7 @@ fun CategoryInfoScreen(
                     groupMemberCount = groupMemberCount,
                     onClicked = {
                         onShowCheckGroupMemberBottomSheetChange(true)
-                    },
-                    isGroupReader = isGroupReader
+                    }
                 )
                 HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)
                 Spacer(Modifier.height(37.dp))

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/EndOfEditingDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/EndOfEditingDialog.kt
@@ -1,0 +1,26 @@
+package com.tico.pomorodo.ui.category.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextAlign
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
+import com.tico.pomorodo.ui.common.view.SimpleText
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun EndOfEditingDialog(onConfirmation: () -> Unit, onDismissRequest: () -> Unit) {
+    SimpleAlertDialog(
+        dialogTitleId = R.string.title_end_of_editing,
+        confirmTextId = R.string.content_finish,
+        dismissTextId = R.string.content_cancel,
+        onConfirmation = onConfirmation,
+        onDismissRequest = onDismissRequest
+    ) {
+        SimpleText(
+            textId = R.string.content_end_of_editing_message,
+            style = PomoroDoTheme.typography.laundryGothicRegular14,
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/EndOfWritingDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/EndOfWritingDialog.kt
@@ -1,0 +1,26 @@
+package com.tico.pomorodo.ui.category.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextAlign
+import com.tico.pomorodo.R
+import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
+import com.tico.pomorodo.ui.common.view.SimpleText
+import com.tico.pomorodo.ui.theme.PomoroDoTheme
+
+@Composable
+fun EndOfWritingDialog(onConfirmation: () -> Unit, onDismissRequest: () -> Unit) {
+    SimpleAlertDialog(
+        dialogTitleId = R.string.title_end_of_writing,
+        confirmTextId = R.string.content_finish,
+        dismissTextId = R.string.content_cancel,
+        onConfirmation = onConfirmation,
+        onDismissRequest = onDismissRequest
+    ) {
+        SimpleText(
+            textId = R.string.content_end_of_writing_message,
+            style = PomoroDoTheme.typography.laundryGothicRegular14,
+            color = PomoroDoTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -233,4 +233,7 @@
     <string name="title_end_of_editing">수정 종료</string>
     <string name="content_end_of_editing_message">수정을 종료하고 나가시겠습니까?\n변경사항은 저장되지 않습니다.</string>
 
+    // end of writing
+    <string name="title_end_of_writing">작성 종료</string>
+    <string name="content_end_of_writing_message">작성을 종료하고 나가시겠습니까?\n변경사항은 저장되지 않습니다.</string>
 </resources>

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -228,4 +228,9 @@
     <string name="title_connected_network_change_online_mode">네트워크가 연결되었습니다. 온라인 모드로 전환하시겠습니까?</string>
     <string name="content_change_online_mode">전환</string>
     <string name="title_disconnected_network">"네트워크 연결이 해제되었습니다. 오프라인 모드로 전환됩니다."</string>
+
+    // end of editing
+    <string name="title_end_of_editing">수정 종료</string>
+    <string name="content_end_of_editing_message">수정을 종료하고 나가시겠습니까?\n변경사항은 저장되지 않습니다.</string>
+
 </resources>


### PR DESCRIPTION
변경사항

- 편집 종료 다이얼로그 구현
  - 편집 종료 다이얼로그 string 추가
- 카테고리 정보/설정의 UI 일부 수정 및 편집 종료 다이얼로그 추가
  - 하단 버튼에 공백 추가
  - 그룹원일 경우 텍스트 입력창이 아닌 일반 텍스트로 변경
  - 그룹원일 경우 상단 ok 버튼 제거
  - 그룹원 아이콘 통일
  - 카테고리 소제목들 bold로 변경
  - 상단 뒤로가기 버튼 또는 시스템 뒤로가기를 누를 때, 편집 종료 다이얼로그 띄우기(단, 그룹원일 경우에는 띄우지 않음)
  - 불필요한 매개변수 isGroup 제거

- 카테고리 추가에서 작성 종료 다이얼로그 구현
  - 작성 종료 다이얼로그 string 추가
- 카테고리 추가의 작성 종료 다이얼로그 추가
  - 상단의 뒤로가기 버튼 또는 시스템 뒤로가기 누르면 작성 종료 다이얼로그 띄우기


Fixes: TICO-429