### PR TITLE
[FEAT] 오프라인 ui 처리 (TICO-369)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -50,7 +50,8 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             todoScreen(
                 navigateToCategory = navController::navigateToCategory,
                 navigateToAddCategory = navController::navigateToAddCategory,
-                navigateToHistory = navController::navigateToHistory
+                navigateToHistory = navController::navigateToHistory,
+                isOffline = appState.isOffline.value
             )
             followScreen(navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen)
             myInfoScreen(
@@ -74,14 +75,17 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                     navController.navigateToInfoCategory(
                         categoryId = categoryId
                     )
-                }
+                },
+                isOffline = appState.isOffline.value
             )
             addCategoryScreen(
                 navigateToGroupMemberChoose = navController::navigateToGroupMemberChoose,
-                navigateToBack = navController::popBackStack
+                navigateToBack = navController::popBackStack,
+                isOffline = appState.isOffline.value
             )
             infoCategoryScreen(
-                navigateToBack = navController::popBackStack
+                navigateToBack = navController::popBackStack,
+                isOffline = appState.isOffline.value
             )
             groupMemberChooseScreen(
                 navController = navController,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -102,14 +102,16 @@ fun NavGraphBuilder.timerScreen(
 fun NavGraphBuilder.todoScreen(
     navigateToAddCategory: () -> Unit,
     navigateToCategory: () -> Unit,
-    navigateToHistory: () -> Unit
+    navigateToHistory: () -> Unit,
+    isOffline: Boolean,
 ) {
     composable(route = BottomNavigationDestination.TODO.name) {
         BackOnPressed()
         TodoScreenRoute(
             navigateToAddCategory = navigateToAddCategory,
             navigateToCategory = navigateToCategory,
-            navigateToHistory = navigateToHistory
+            navigateToHistory = navigateToHistory,
+            isOffline = isOffline
         )
     }
 }
@@ -207,13 +209,15 @@ fun NavGraphBuilder.breakModeScreen(mainNavController: NavController, getState: 
 fun NavGraphBuilder.categoryScreen(
     navigateToAddCategory: () -> Unit,
     navigateToInfoCategory: (Int) -> Unit,
-    navigateToBack: () -> Unit
+    navigateToBack: () -> Unit,
+    isOffline: Boolean,
 ) {
     composable(route = MainNavigationDestination.CATEGORY.name) {
         CategoryScreenRoute(
             navigateToAddCategory = navigateToAddCategory,
             navigateToBack = navigateToBack,
-            navigateToInfoCategory = navigateToInfoCategory
+            navigateToInfoCategory = navigateToInfoCategory,
+            isOffline = isOffline
         )
     }
 }
@@ -221,11 +225,13 @@ fun NavGraphBuilder.categoryScreen(
 fun NavGraphBuilder.addCategoryScreen(
     navigateToGroupMemberChoose: (String) -> Unit,
     navigateToBack: () -> Unit,
+    isOffline: Boolean
 ) {
     composable(route = MainNavigationDestination.ADD_CATEGORY.name) {
         CategoryAddScreenRoute(
             navigateToBack = navigateToBack,
             navigateToGroupMemberChoose = navigateToGroupMemberChoose,
+            isOffline = isOffline
         )
     }
 }
@@ -239,7 +245,8 @@ internal class CategoryArgs(savedStateHandle: SavedStateHandle) {
 }
 
 fun NavGraphBuilder.infoCategoryScreen(
-    navigateToBack: () -> Unit
+    navigateToBack: () -> Unit,
+    isOffline: Boolean,
 ) {
     composable(
         route = "${MainNavigationDestination.INFO_CATEGORY.name}/{$CATEGORY_ID}",
@@ -247,6 +254,7 @@ fun NavGraphBuilder.infoCategoryScreen(
     ) {
         CategoryInfoScreenRoute(
             navigateToBack = navigateToBack,
+            isOffline = isOffline
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.tico.pomorodo.ui
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -20,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.tico.pomorodo.R
 import com.tico.pomorodo.navigation.AppNavHost
+import com.tico.pomorodo.navigation.BottomNavigationDestination
 import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.home.view.BottomBar
 import com.tico.pomorodo.ui.home.view.rememberAppState
@@ -28,10 +28,19 @@ import com.tico.pomorodo.ui.theme.PomoroDoTheme
 @Composable
 fun MainScreen() {
     val appState = rememberAppState()
-    val homeTabs = appState.bottomNavigationDestinationList.map { it.name }.toSet()
     val context = LocalContext.current
+    val allTabs = appState.bottomNavigationDestinationList
+    val homeTabsRoutes = allTabs.map { it.name }.toSet()
+    val currentRoute = appState.currentDestination?.route
 
-    LaunchedEffect(key1 = appState.isNetworkConnected.value, key2 = appState.isOffline.value) {
+    LaunchedEffect(appState.isOffline.value, currentRoute) {
+        val isNowFollow = currentRoute == BottomNavigationDestination.FOLLOW.name
+        if (appState.isOffline.value && isNowFollow) {
+            appState.navigateToDestination(BottomNavigationDestination.TIMER)
+        }
+    }
+
+    LaunchedEffect(appState.isNetworkConnected.value) {
         if (appState.isNetworkConnected.value) {
             if (appState.isOffline.value) {
                 val result = appState.snackBarHostState.showSnackbar(
@@ -55,9 +64,13 @@ fun MainScreen() {
         modifier = Modifier.fillMaxSize(),
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
-            val currentRoute = appState.currentDestination?.route
-            if (currentRoute in homeTabs) {
-                BottomBar(appState)
+            if (currentRoute in homeTabsRoutes) {
+                BottomBar(
+                    currentDestination = appState.currentDestination,
+                    navigateToDestination = appState::navigateToDestination,
+                    isOffline = appState.isOffline.value,
+                    destinations = allTabs
+                )
             }
         },
         containerColor = PomoroDoTheme.colorScheme.background,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.tico.pomorodo.R
 import com.tico.pomorodo.navigation.AppNavHost
+import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.home.view.BottomBar
 import com.tico.pomorodo.ui.home.view.rememberAppState
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
@@ -45,11 +46,7 @@ fun MainScreen() {
                 }
             }
         } else {
-            Toast.makeText(
-                appState.navController.context,
-                context.getString(R.string.title_disconnected_network),
-                Toast.LENGTH_LONG
-            ).show()
+            context.executeToast(R.string.title_disconnected_network)
             appState.setIsOffline(true)
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryAddScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.RadioButtonColors
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -55,6 +56,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun CategoryAddScreen(
+    isOffline: Boolean,
     title: String,
     type: CategoryType,
     groupMemberCount: Int,
@@ -64,11 +66,11 @@ fun CategoryAddScreen(
     onShowOpenSettingsBottomSheetChange: (Boolean) -> Unit,
     onGroupMemberChooseClicked: () -> Unit,
 ) {
-    val radioButtonColors = RadioButtonColors(
+    val radioButtonColors = RadioButtonDefaults.colors(
         selectedColor = PomoroDoTheme.colorScheme.onBackground,
         unselectedColor = PomoroDoTheme.colorScheme.onBackground,
-        disabledSelectedColor = Color.Unspecified,
-        disabledUnselectedColor = Color.Unspecified
+        disabledSelectedColor = PomoroDoTheme.colorScheme.gray70,
+        disabledUnselectedColor = PomoroDoTheme.colorScheme.gray70
     )
     val textFieldColors = TextFieldDefaults.colors(
         focusedTextColor = PomoroDoTheme.colorScheme.onBackground,
@@ -105,7 +107,12 @@ fun CategoryAddScreen(
                 colors = textFieldColors,
                 textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
             )
-            CategoryType(type = type, colors = radioButtonColors, onTypeChanged = onTypeChanged)
+            CategoryType(
+                type = type,
+                colors = radioButtonColors,
+                onTypeChanged = onTypeChanged,
+                isOffline = isOffline
+            )
             HorizontalDivider(color = PomoroDoTheme.colorScheme.gray90)
             CategoryOpenSettings(
                 iconString = openSettingOption.iconString,
@@ -227,6 +234,7 @@ fun CategoryOpenSettings(
 
 @Composable
 private fun CategoryType(
+    isOffline: Boolean,
     type: CategoryType,
     colors: RadioButtonColors,
     onTypeChanged: (CategoryType) -> Unit
@@ -261,13 +269,14 @@ private fun CategoryType(
                 selected = type == CategoryType.GROUP,
                 onClick = { onTypeChanged(CategoryType.GROUP) },
                 colors = colors,
-                padding = PaddingValues(horizontal = 5.dp)
+                padding = PaddingValues(horizontal = 5.dp),
+                enabled = !isOffline
             )
             SimpleText(
-                modifier = Modifier.clickableWithoutRipple { onTypeChanged(CategoryType.GROUP) },
+                modifier = Modifier.clickableWithoutRipple(!isOffline) { onTypeChanged(CategoryType.GROUP) },
                 textId = R.string.content_category_group,
                 style = PomoroDoTheme.typography.laundryGothicRegular14,
-                color = PomoroDoTheme.colorScheme.onBackground
+                color = if (isOffline) colors.disabledUnselectedColor else PomoroDoTheme.colorScheme.onBackground
             )
         }
     }
@@ -279,6 +288,7 @@ fun CategoryAddScreenRoute(
     viewModel: CategoryAddViewModel = hiltViewModel(),
     navigateToBack: () -> Unit,
     navigateToGroupMemberChoose: (String) -> Unit,
+    isOffline: Boolean
 ) {
     val openSettingsOptionSheetState = rememberModalBottomSheetState()
     var showOpenSettingsBottomSheet by rememberSaveable { mutableStateOf(false) }
@@ -351,6 +361,7 @@ fun CategoryAddScreenRoute(
                 )
             }
             CategoryAddScreen(
+                isOffline = isOffline,
                 title = title,
                 type = type,
                 groupMemberCount = selectedGroupMembers.filter { it.selected }.size,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryScreen.kt
@@ -35,6 +35,7 @@ import com.tico.pomorodo.ui.todo.view.CategoryTag
 
 @Composable
 fun CategoryScreen(
+    isOffline: Boolean,
     generalCategoryList: List<Category>,
     groupCategoryList: List<Category>,
     inviteGroupCategoryList: List<InviteCategory>,
@@ -104,20 +105,22 @@ fun CategoryScreen(
                     }
                 }
             }
-            Column(modifier = Modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                SimpleText(
-                    textId = R.string.content_category_invited_group,
-                    style = PomoroDoTheme.typography.laundryGothicBold16,
-                    color = PomoroDoTheme.colorScheme.onBackground
-                )
-                Column(modifier = Modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    inviteGroupCategoryList.forEach { category ->
-                        InvitedCategoryItem(
-                            title = category.title,
-                            groupReader = category.groupReader,
-                            onAcceptButtonClicked = {},
-                            onRejectButtonClicked = {}
-                        )
+            if (!isOffline) {
+                Column(modifier = Modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    SimpleText(
+                        textId = R.string.content_category_invited_group,
+                        style = PomoroDoTheme.typography.laundryGothicBold16,
+                        color = PomoroDoTheme.colorScheme.onBackground
+                    )
+                    Column(modifier = Modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        inviteGroupCategoryList.forEach { category ->
+                            InvitedCategoryItem(
+                                title = category.title,
+                                groupReader = category.groupReader,
+                                onAcceptButtonClicked = {},
+                                onRejectButtonClicked = {}
+                            )
+                        }
                     }
                 }
             }
@@ -197,7 +200,8 @@ fun CategoryScreenRoute(
     categoryViewModel: CategoryViewModel = hiltViewModel(),
     navigateToAddCategory: () -> Unit,
     navigateToBack: () -> Unit,
-    navigateToInfoCategory: (Int) -> Unit
+    navigateToInfoCategory: (Int) -> Unit,
+    isOffline: Boolean,
 ) {
     val categoryList by categoryViewModel.categoryList.collectAsState()
     val inviteGroupCategoryList by categoryViewModel.inviteGroupCategoryList.collectAsState()
@@ -222,7 +226,8 @@ fun CategoryScreenRoute(
                 inviteGroupCategoryList = inviteGroupCategoryList,
                 generalCategoryList = categoryList.filter { it.groupMemberCount == 0 },
                 groupCategoryList = categoryList.filter { it.groupMemberCount > 0 },
-                onCategoryClicked = navigateToInfoCategory
+                onCategoryClicked = navigateToInfoCategory,
+                isOffline = isOffline
             )
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/BackOnPressed.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/BackOnPressed.kt
@@ -1,7 +1,6 @@
 package com.tico.pomorodo.ui.common.view
 
 import android.app.Activity
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,11 +22,7 @@ fun BackOnPressed() {
             (context as Activity).finish()
         } else {
             backPressedState = true
-            Toast.makeText(
-                context,
-                context.getString(R.string.content_back_on_pressed_more_app_excute),
-                Toast.LENGTH_SHORT
-            ).show()
+            context.executeToast(R.string.content_back_on_pressed_more_app_excute)
         }
         backPressedTime = System.currentTimeMillis()
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/BottomBar.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/BottomBar.kt
@@ -7,32 +7,46 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
+import com.tico.pomorodo.R
+import com.tico.pomorodo.navigation.BottomNavigationDestination
+import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
 fun BottomBar(
-    appState: AppState
+    currentDestination: NavDestination?,
+    isOffline: Boolean,
+    navigateToDestination: (BottomNavigationDestination) -> Unit,
+    destinations: List<BottomNavigationDestination>
 ) {
+    val context = LocalContext.current
     NavigationBar(
         modifier = Modifier.height(60.dp),
         containerColor = PomoroDoTheme.colorScheme.secondaryContainer,
     ) {
-        appState.bottomNavigationDestinationList.forEach { destination ->
+        destinations.forEach { destination ->
+            val selected = currentDestination
+                ?.hierarchy
+                ?.any { it.route == destination.name } == true
             NavigationBarItem(
-                selected = appState.currentDestination?.hierarchy?.any {
-                    it.route?.contains(destination.name, true) == true
-                } == true,
+                selected = selected,
                 onClick = {
-                    appState.navigateToDestination(destination)
+                    if (isOffline && destination == BottomNavigationDestination.FOLLOW) {
+                        context.executeToast(R.string.title_not_support_offline_mode)
+                    } else {
+                        navigateToDestination(destination)
+                    }
                 },
                 icon = {
                     Column(
@@ -43,7 +57,6 @@ fun BottomBar(
                         Icon(
                             modifier = Modifier.size(26.dp),
                             imageVector = requireNotNull(PomoroDoTheme.iconPack[destination.iconString]),
-                            tint = Color.Unspecified,
                             contentDescription = stringResource(id = destination.iconTextId)
                         )
                         Text(
@@ -52,14 +65,12 @@ fun BottomBar(
                         )
                     }
                 },
-                colors = NavigationBarItemColors(
+                colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = PomoroDoTheme.colorScheme.primary,
                     selectedTextColor = PomoroDoTheme.colorScheme.primary,
-                    selectedIndicatorColor = Color.Unspecified,
+                    indicatorColor = Color.Transparent,
                     unselectedIconColor = PomoroDoTheme.colorScheme.onBackground,
-                    unselectedTextColor = PomoroDoTheme.colorScheme.onBackground,
-                    disabledIconColor = Color.Unspecified,
-                    disabledTextColor = Color.Unspecified
+                    unselectedTextColor = PomoroDoTheme.colorScheme.onBackground
                 )
             )
         }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FriendTodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FriendTodoScreen.kt
@@ -140,8 +140,9 @@ fun FriendTodoScreen(
         CategorySection(
             isFriend = true,
             categoryWithTodoItemList = categoryWithTodoItemList,
+            onLikedIconClicked = onLikedIconClicked,
             onGroupIconClicked = onGroupIconClicked,
-            onLikedIconClicked = onLikedIconClicked
+            isOffline = false
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
@@ -203,6 +203,7 @@ fun TodoListItem(
     onGroupIconClicked: () -> Unit,
     onUpdateTodoItem: () -> Unit,
     onLikedIconClicked: () -> Unit,
+    isOffline: Boolean,
 ) {
     var showDropDownMoreInfo by remember { mutableStateOf(false) }
     Row(
@@ -228,14 +229,14 @@ fun TodoListItem(
             )
         }
 
-        if (isGroup && !isFriend) {
+        if (isGroup && !isFriend && !isOffline) {
             TodoGroupButton(
                 groupNumber = todoData.completedList?.size ?: 0,
                 onGroupClicked = onGroupIconClicked
             )
         }
 
-        if (isFriend || todoData.likes > 0) {
+        if ((isFriend || todoData.likes > 0) && !isOffline) {
             TodoLikeButton(
                 likes = todoData.likes,
                 isFriend = isFriend,
@@ -244,7 +245,7 @@ fun TodoListItem(
             )
         }
 
-        if (!isFriend) {
+        if (!isFriend && (!isOffline || !isGroup)) {
             MoreInfoButton(
                 showMoreInfo = showDropDownMoreInfo,
                 onShowMoreInfoChange = { showDropDownMoreInfo = it },

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -236,4 +236,7 @@
     // end of writing
     <string name="title_end_of_writing">작성 종료</string>
     <string name="content_end_of_writing_message">작성을 종료하고 나가시겠습니까?\n변경사항은 저장되지 않습니다.</string>
+
+    // offline mode
+    <string name="title_not_support_offline_mode">오프라인 모드에서 지원하지 않는 기능입니다.</string>
 </resources>


### PR DESCRIPTION
변경사항

- 오프라인 모드 토스트 메시지 string 추가

- 기존에 있는 executeToast로 변경

- 오프라인 UI 처리
  - 오프라인일 때, follow 탭을 클릭하면 토스트 메시지 안내
    - appState를 매개변수로 넘기는 것이 아닌 필요한 데이터를 매개변수로 전달
    - bottomBar의 color를 default를 사용한 것으로 변경
    - 오프라인일 때, follow 탭을 클릭하면 토스트 메시지 안내
    - 오프라인으로 변경했을 때, 현재 follow 탭이라면 타이머 화면으로 이동
    - 투두리스트의 카테고리 태그
      - 일반 카테고리는 생성 가능
      - 그룹 카테고리는 생성 불가능

    - 투두리스트의 투두
      - 일반 카테고리의 투두는 전부 가능
      - 그룹 카테고리의 투두는 상태변경만 가능

    - 카테고리에서 초대받은 그룹 표시 안 함

    - 카테고리 추가
      - 그룹 라디오 버튼 비활성화 및 색상 gray50으로 적용

    - 카테고리 정보/설정
      - 일반 카테고리의 하단의 삭제 버튼 표시 안 함
      - 그룹 카테고리의 하단의 삭제, 나가기 버튼 표시 안 함
      - 그룹 카테고리의 상단의 수정 버튼 표시 안하고, 뒤로가기 시, 다이얼로그 안 띄움
      - 그룹 카테고리의 카테고리 제목 일반 텍스트로 변경


Resolves: TICO-369