### PR TITLE
[REFACTOR] 관리자 도메인 정책 변경 및 검증 로직 개선 (TICO-428)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/controller/AdminController.java
@@ -1,7 +1,8 @@
 package com.tico.pomoro_do.domain.user.controller;
 
 import com.tico.pomoro_do.domain.auth.dto.response.TokenResponse;
-import com.tico.pomoro_do.domain.user.dto.request.AdminRequest;
+import com.tico.pomoro_do.domain.user.dto.request.AdminLoginRequest;
+import com.tico.pomoro_do.domain.user.dto.request.AdminRegisterRequest;
 import com.tico.pomoro_do.domain.user.service.AdminService;
 import com.tico.pomoro_do.global.response.SuccessCode;
 import com.tico.pomoro_do.global.response.SuccessResponse;
@@ -33,14 +34,14 @@ public class AdminController {
     /**
      * 관리자 회원가입 API
      *
-     * @param request AdminRequest 객체
+     * @param request AdminRegisterRequest 객체
      * @param profileImage 관리자 프로필 이미지 파일
      * @return 성공 시 TokenResponse를 포함하는 SuccessResponse 반환
      */
     @Operation(
             summary = "관리자 회원가입",
             description = "관리자 회원가입을 수행합니다. <br>"
-                    + "관리자의 이메일은 @pomorodo.shop 도메인으로 제한됩니다. <br>"
+                    + "관리자의 이메일은 @pomorodo.invalid 도메인으로 제한됩니다. <br>"
                     + "성공 시에는 TokenResponse를 포함하는 SuccessResponse를 반환합니다."
     )
     @ApiResponses(value = {
@@ -49,12 +50,12 @@ public class AdminController {
             @ApiResponse(responseCode = "409", description = "이미 등록된 사용자")
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SuccessResponse<TokenResponse>> adminJoin(
-            @Valid @RequestPart AdminRequest request,
+    public ResponseEntity<SuccessResponse<TokenResponse>> registerAdmin(
+            @Valid @RequestPart AdminRegisterRequest request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
 
-        TokenResponse jwtResponse = adminService.adminJoin(request, profileImage);
+        TokenResponse jwtResponse = adminService.registerAdmin(request, profileImage);
         SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                 .message(SuccessCode.ADMIN_SIGNUP_SUCCESS.getMessage())
                 .data(jwtResponse)
@@ -66,7 +67,7 @@ public class AdminController {
     /**
      * 관리자 로그인 API
      *
-     * @param request AdminRequest 객체
+     * @param request AdminLoginRequest 객체
      * @return 성공 시 TokenResponse를 포함하는 SuccessResponse 반환
      */
     @Operation(
@@ -81,11 +82,11 @@ public class AdminController {
             @ApiResponse(responseCode = "403", description = "관리자 권한이 없음")
     })
     @PostMapping("/login")
-    public ResponseEntity<SuccessResponse<TokenResponse>> adminLogin(
-            @Valid @RequestBody AdminRequest request
+    public ResponseEntity<SuccessResponse<TokenResponse>> loginAdmin(
+            @Valid @RequestBody AdminLoginRequest request
     ) {
         log.info("관리자 로그인 요청: {}", request.getEmail());
-        TokenResponse jwtResponse = adminService.adminLogin(request);
+        TokenResponse jwtResponse = adminService.loginAdmin(request);
         SuccessResponse<TokenResponse> successResponse = SuccessResponse.<TokenResponse>builder()
                 .message(SuccessCode.ADMIN_LOGIN_SUCCESS.getMessage())
                 .data(jwtResponse)

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminLoginRequest.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminLoginRequest.java
@@ -1,0 +1,20 @@
+package com.tico.pomoro_do.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "Admin Login Request")
+public class AdminLoginRequest {
+
+    @Schema(example = "dev-admin@pomorodo.invalid", description = "관리자 이메일")
+    @NotBlank
+    @Email
+    private String email;
+
+    @Schema(example = "dev-admin", description = "닉네임")
+    @NotBlank
+    private String nickname;
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminRegisterRequest.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/dto/request/AdminRegisterRequest.java
@@ -6,17 +6,22 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
+/**
+ * 관리자 회원가입 요청 DTO
+ * - email: 내부 전용 도메인(@pomorodo.invalid)만 허용
+ * - nickname: 최대 10자, 필수
+ */
 @Getter
-@Schema(description = "Admin Info")
-public class AdminRequest {
+@Schema(description = "Admin Register Request")
+public class AdminRegisterRequest {
 
+    @Schema(example = "dev-admin@pomorodo.invalid", description = "관리자 이메일")
+    @NotBlank(message = "관리자 이메일을 입력해주세요.")
     @Email
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Schema(description = "이메일", example = "chadoll@pomorodo.shop")
     private String email;
 
     @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
     @NotBlank(message = "닉네임을 입력해주세요.")
-    @Schema(description = "닉네임", example = "chadoll")
+    @Schema(example = "dev-admin", description = "닉네임")
     private String nickname;
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/policy/InternalEmailPolicy.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/policy/InternalEmailPolicy.java
@@ -1,0 +1,41 @@
+package com.tico.pomoro_do.domain.user.policy;
+
+import com.tico.pomoro_do.global.exception.CustomException;
+import com.tico.pomoro_do.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+/**
+ * 관리자/더미 계정은 외부와 섞이지 않게 내부 전용 도메인만 허용합니다.
+ * RFC 2606 예약 TLD(.invalid) 사용 → 실제 발송/수신 불가, 안전한 테스트에 적합
+ */
+@Slf4j
+@Component
+public class InternalEmailPolicy {
+
+    @Value("${app.auth.internal-email-domain}")
+    private String internalEmailDomain;
+
+    /** 이메일 정규화(공백 제거, 소문자) */
+    public String normalize(String email) {
+        return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /** 내부 전용 도메인(@pomorodo.invalid) 여부 확인 */
+    public boolean isInternalDomain(String email) {
+        if (email == null) return false;
+        String e = normalize(email);
+        return e.endsWith("@" + internalEmailDomain);
+    }
+
+    /** 관리자/내부 계정만 생성/로그인 허용 */
+    public void validateInternalOnly(String email) {
+        if (!isInternalDomain(email)) {
+            log.warn("관리자 로그인 시도: 허용되지 않은 이메일 {}", email);
+            throw new CustomException(ErrorCode.INVALID_ADMIN_EMAIL);
+        }
+    }
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/user/service/AdminService.java
@@ -1,7 +1,8 @@
 package com.tico.pomoro_do.domain.user.service;
 
 import com.tico.pomoro_do.domain.auth.dto.response.TokenResponse;
-import com.tico.pomoro_do.domain.user.dto.request.AdminRequest;
+import com.tico.pomoro_do.domain.user.dto.request.AdminLoginRequest;
+import com.tico.pomoro_do.domain.user.dto.request.AdminRegisterRequest;
 import com.tico.pomoro_do.global.exception.CustomException;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -10,19 +11,19 @@ public interface AdminService {
     /**
      * 관리자 회원가입
      *
-     * @param adminRequest AdminRequest 객체
+     * @param adminRegisterRequest AdminRegisterRequest 객체
      * @param profileImage 프로필 이미지
      * @return 성공 시 새 Access, Refresh 토큰을 포함하는 TokenResponse
      * @throws CustomException 이메일 도메인이 유효하지 않거나 이미 등록된 사용자인 경우 예외를 던집니다.
      */
-    TokenResponse adminJoin(AdminRequest adminRequest, MultipartFile profileImage);
+    TokenResponse registerAdmin(AdminRegisterRequest adminRegisterRequest, MultipartFile profileImage);
 
     /**
      * 관리자 로그인
      *
-     * @param adminRequest AdminRequest 객체
+     * @param adminLoginRequest AdminLoginRequest 객체
      * @return 성공 시 새 Access, Refresh 토큰을 포함하는 TokenResponse
      * @throws CustomException 이메일 도메인이 유효하지 않거나 관리자가 아닌 경우 예외를 던집니다.
      */
-    TokenResponse adminLogin(AdminRequest adminRequest);
+    TokenResponse loginAdmin(AdminLoginRequest adminLoginRequest);
 }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorCode.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/global/exception/ErrorCode.java
@@ -141,10 +141,10 @@ public enum ErrorCode {
     DEVICE_ID_INVALID(HttpStatus.BAD_REQUEST, "D-303", "DEVICE ID가 비어있거나 유효하지 않습니다"),
 
     // 관리자 관련 에러: -400번대
-    NOT_AN_ADMIN(HttpStatus.FORBIDDEN, "P-400", "관리자 권한이 없습니다."),
-    INVALID_ADMIN_EMAIL(HttpStatus.BAD_REQUEST, "P-401", "허용되지 않은 관리자 이메일입니다."),
-    ADMIN_EMAIL_ONLY(HttpStatus.FORBIDDEN, "P-402", "관리자 이메일만 접근할 수 있습니다."),
-    ADMIN_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "P-403", "관리자 정보가 일치하지 않습니다. 관리자 로그인에 실패했습니다."),
+    NOT_AN_ADMIN(HttpStatus.FORBIDDEN, "I-400", "관리자 권한이 없습니다."),
+    INVALID_ADMIN_EMAIL(HttpStatus.BAD_REQUEST, "I-401", "허용되지 않은 관리자 이메일입니다."),
+    ADMIN_EMAIL_ONLY(HttpStatus.FORBIDDEN, "I-402", "관리자 전용 접근입니다."),
+    ADMIN_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "I-403", "관리자 인증에 실패했습니다."),
 
     // 파일 업로드 관련 에러: -500번대
     FILE_MISSING(HttpStatus.BAD_REQUEST, "F-500", "파일이 요청에 포함되어 있지 않습니다."),

--- a/backend/pomoro-do/src/main/resources/application.yml
+++ b/backend/pomoro-do/src/main/resources/application.yml
@@ -25,6 +25,10 @@ spring:
       max-file-size: 50MB
       max-request-size: 50MB
 
+app:
+  auth:
+    internal-email-domain: ${INTERNAL_EMAIL_DOMAIN}
+
 logging:
   level:
     com.tico.pomoro_do: DEBUG # 'com.tico.pomoro_do' 패키지의 로깅 레벨을 DEBUG로 설정하여 상세한 정보 로깅


### PR DESCRIPTION
- 관리자 이메일을 내부 전용 도메인으로 강제
- 검증 로직을 validateInternalOnly()로 통합

Related to: TICO-446