### PR TITLE
[ERROR] NavigationRoute가 전부 지워지지 않아 발생한 오류 해결(TICO-434)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
@@ -16,7 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.tico.pomorodo.MainViewModel
 import com.tico.pomorodo.navigation.BottomNavigationDestination
-import com.tico.pomorodo.navigation.NavigationRoute
+import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.navigation.navigateToFollow
 import com.tico.pomorodo.navigation.navigateToMyInfo
 import com.tico.pomorodo.navigation.navigateToTimer
@@ -63,7 +63,7 @@ data class AppState(
 
     fun navigateToDestination(topLevelDestination: BottomNavigationDestination) {
         val navOptions = navOptions {
-            popUpTo(NavigationRoute.HOME.name) { saveState = true }
+            popUpTo(MainNavigationDestination.HOME.name) { saveState = true }
             launchSingleTop = true
             restoreState = true
         }


### PR DESCRIPTION
AppState.kt의 NavigationRoute 참조를 MainNavigationDestination으로 변경

Fixes: TICO-434
Related to: TICO-432