### PR TITLE
[FEAT] 팔로우 투두 리스트 이동 기능(TICO-431)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/local/datasource/DataSource.kt
@@ -6,9 +6,11 @@ import com.tico.pomorodo.data.local.entity.TodoEntity
 import com.tico.pomorodo.data.local.entity.UserEntity
 import com.tico.pomorodo.data.model.CalendarFocusState
 import com.tico.pomorodo.data.model.CategoryType
+import com.tico.pomorodo.data.model.CategoryWithTodoItem
 import com.tico.pomorodo.data.model.InviteCategory
 import com.tico.pomorodo.data.model.OpenSettings
 import com.tico.pomorodo.data.model.TimerSettingData
+import com.tico.pomorodo.data.model.TodoData
 import com.tico.pomorodo.data.model.TodoState
 import com.tico.pomorodo.data.model.User
 import com.tico.pomorodo.domain.model.Follow
@@ -50,17 +52,22 @@ object DataSource {
     )
 
     val followList = listOf(
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
-        Follow(followId = 0, name = "모카커피짱귀엽", isFollowing = true),
+        Follow(followId = 1, name = "사용자 1", isFollowing = true),
+        Follow(followId = 2, name = "사용자 2", isFollowing = true),
+        Follow(followId = 3, name = "사용자 3", isFollowing = true),
+        Follow(followId = 4, name = "구름이2", isFollowing = true),
+        Follow(followId = 5, name = "구름이3", isFollowing = true),
+        Follow(followId = 6, name = "구름이4", isFollowing = true),
+        Follow(followId = 7, name = "모카커피1", isFollowing = true),
+        Follow(followId = 8, name = "모카커피2", isFollowing = true),
+        Follow(followId = 9, name = "모카커피3", isFollowing = true),
+        Follow(followId = 10, name = "모카커피4", isFollowing = true),
+        Follow(followId = 11, name = "모카커피5", isFollowing = true),
+        Follow(followId = 12, name = "a", isFollowing = true),
+        Follow(followId = 13, name = "b", isFollowing = true),
+        Follow(followId = 14, name = "차돌1", isFollowing = true),
+        Follow(followId = 15, name = "차돌2", isFollowing = true),
+        Follow(followId = 16, name = "구름이1", isFollowing = true),
     )
 
     val INITIAL_TODO_DATA = listOf(
@@ -69,7 +76,7 @@ object DataSource {
             title = "Todo 1",
             categoryId = 1,
             status = TodoState.UNCHECKED,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2,
         ),
         TodoEntity(
@@ -77,7 +84,7 @@ object DataSource {
             title = "Todo 2",
             categoryId = 1,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -85,28 +92,28 @@ object DataSource {
             title = "Todo 3",
             categoryId = 2,
             status = TodoState.UNCHECKED,
-            targetDate = LocalDate(2024, 12, 5)
+            targetDate = LocalDate(2025, 8, 27)
         ),
         TodoEntity(
             id = 4,
             title = "Todo 4",
             categoryId = 3,
             status = TodoState.CHECKED,
-            targetDate = LocalDate(2024, 12, 5)
+            targetDate = LocalDate(2025, 8, 27)
         ),
         TodoEntity(
             id = 5,
             title = "Todo 5",
             categoryId = 4,
             status = TodoState.CHECKED,
-            targetDate = LocalDate(2024, 12, 5)
+            targetDate = LocalDate(2025, 8, 27)
         ),
         TodoEntity(
             id = 6,
             title = "Todo 6",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -114,7 +121,7 @@ object DataSource {
             title = "Todo 7",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -122,7 +129,7 @@ object DataSource {
             title = "Todo 8",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -130,7 +137,7 @@ object DataSource {
             title = "Todo 9",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -138,7 +145,7 @@ object DataSource {
             title = "Todo 10",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         ),
         TodoEntity(
@@ -146,7 +153,7 @@ object DataSource {
             title = "Todo 11",
             categoryId = 4,
             status = TodoState.GOING,
-            targetDate = LocalDate(2024, 12, 5),
+            targetDate = LocalDate(2025, 8, 27),
             likes = 2
         )
     )
@@ -163,7 +170,10 @@ object DataSource {
             groupMember = listOf(
                 UserEntity(id = 1, name = "사용자 1", email = "abc@abc.abc"),
                 UserEntity(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
-                UserEntity(id = 3, name = "사용자 3", email = "abce@abc.abc")
+                UserEntity(id = 3, name = "사용자 3", email = "abce@abc.abc"),
+                UserEntity(id = 4, name = "구름이2", email = "abc@gmail.com"),
+                UserEntity(id = 5, name = "구름이3", email = "abc@gmail.com"),
+                UserEntity(id = 6, name = "구름이4", email = "abc@gmail.com"),
             ),
         ),
         CategoryEntity(
@@ -175,9 +185,11 @@ object DataSource {
             isGroupReader = false,
             groupReader = "사용자 2",
             groupMember = listOf(
-                UserEntity(id = 1, name = "사용자 1", email = "abc@abc.abc"),
-                UserEntity(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
-                UserEntity(id = 3, name = "사용자 3", email = "abce@abc.abc")
+                UserEntity(id = 7, name = "모카커피1", email = "abc@gmail.com"),
+                UserEntity(id = 8, name = "모카커피2", email = "abc@gmail.com"),
+                UserEntity(id = 9, name = "모카커피3", email = "abc@gmail.com"),
+                UserEntity(id = 10, name = "모카커피4", email = "abc@gmail.com"),
+                UserEntity(id = 11, name = "모카커피5", email = "abc@gmail.com"),
             ),
         ),
         CategoryEntity(
@@ -212,4 +224,191 @@ object DataSource {
         time = LocalTime(1, 0, 0),
         updatedAt = System.currentTimeMillis()
     )
+
+    val categoryWithTodoItemList =
+        listOf(
+            CategoryWithTodoItem(
+                categoryId = 1,
+                title = "그룹 카테고리 1",
+                type = CategoryType.GROUP,
+                todoList = listOf(
+                    TodoData(
+                        id = 1,
+                        title = "Group Todo 1",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 1,
+                        completedList = listOf(
+                            User(id = 1, name = "사용자 1", email = "abc@abc.abc"),
+                            User(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
+                            User(id = 3, name = "사용자 3", email = "abce@abc.abc")
+                        ),
+                        incompletedList = listOf(
+                            User(id = 4, name = "구름이2", email = "abc@gmail.com"),
+                            User(id = 5, name = "구름이3", email = "abc@gmail.com"),
+                            User(id = 6, name = "구름이4", email = "abc@gmail.com"),
+                        ),
+                        likes = 2,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 1,
+                        title = "Group Todo 2",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 1,
+                        completedList = listOf(
+                            User(id = 1, name = "사용자 1", email = "abc@abc.abc"),
+                            User(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
+                            User(id = 3, name = "사용자 3", email = "abce@abc.abc"),
+                            User(id = 4, name = "구름이2", email = "abc@gmail.com"),
+                            User(id = 5, name = "구름이3", email = "abc@gmail.com"),
+                        ),
+                        incompletedList = listOf(
+                            User(id = 6, name = "구름이4", email = "abc@gmail.com"),
+                        ),
+                        likes = 0,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                ),
+                openSettings = OpenSettings.GROUP,
+                groupMemberCount = 6,
+                groupMember = listOf(
+                    User(id = 1, name = "사용자 1", email = "abc@abc.abc"),
+                    User(id = 2, name = "사용자 2", email = "abcd@abc.abc"),
+                    User(id = 3, name = "사용자 3", email = "abce@abc.abc"),
+                    User(id = 4, name = "구름이2", email = "abc@gmail.com"),
+                    User(id = 5, name = "구름이3", email = "abc@gmail.com"),
+                    User(id = 6, name = "구름이4", email = "abc@gmail.com"),
+                )
+            ),
+            CategoryWithTodoItem(
+                categoryId = 2,
+                title = "그룹 카테고리 2",
+                type = CategoryType.GROUP,
+                todoList = listOf(
+                    TodoData(
+                        id = 3,
+                        title = "Group Todo 1",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 2,
+                        completedList = listOf(),
+                        incompletedList = listOf(
+                            User(id = 7, name = "모카커피1", email = "abc@gmail.com"),
+                            User(id = 8, name = "모카커피2", email = "abc@gmail.com"),
+                            User(id = 9, name = "모카커피3", email = "abc@gmail.com"),
+                            User(id = 10, name = "모카커피4", email = "abc@gmail.com"),
+                            User(id = 11, name = "모카커피5", email = "abc@gmail.com"),
+                        ),
+                        likes = 2,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 4,
+                        title = "Group Todo 2",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 2,
+                        completedList = listOf(
+                            User(id = 7, name = "모카커피1", email = "abc@gmail.com"),
+                            User(id = 8, name = "모카커피2", email = "abc@gmail.com"),
+                            User(id = 9, name = "모카커피3", email = "abc@gmail.com"),
+                            User(id = 10, name = "모카커피4", email = "abc@gmail.com"),
+                            User(id = 11, name = "모카커피5", email = "abc@gmail.com"),
+                        ),
+                        incompletedList = listOf(),
+                        likes = 0,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                ),
+                openSettings = OpenSettings.GROUP,
+                groupMemberCount = 5,
+                groupMember = listOf(
+                    User(id = 7, name = "모카커피1", email = "abc@gmail.com"),
+                    User(id = 8, name = "모카커피2", email = "abc@gmail.com"),
+                    User(id = 9, name = "모카커피3", email = "abc@gmail.com"),
+                    User(id = 10, name = "모카커피4", email = "abc@gmail.com"),
+                    User(id = 11, name = "모카커피5", email = "abc@gmail.com"),
+                )
+            ),
+            CategoryWithTodoItem(
+                categoryId = 3,
+                title = "일반 카테고리 1",
+                type = CategoryType.GENERAL,
+                todoList = listOf(
+                    TodoData(
+                        id = 5,
+                        title = "General Todo 1",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 3,
+                        likes = 2,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 6,
+                        title = "General Todo 2",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 3,
+                        likes = 0,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 7,
+                        title = "General Todo 3",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 3,
+                        likes = 5,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                ),
+            ),
+            CategoryWithTodoItem(
+                categoryId = 4,
+                title = "일반 카테고리 2",
+                type = CategoryType.GENERAL,
+                todoList = listOf(
+                    TodoData(
+                        id = 8,
+                        title = "General Todo 1",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 4,
+                        likes = 2,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 9,
+                        title = "General Todo 2",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 4,
+                        likes = 0,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                    TodoData(
+                        id = 10,
+                        title = "General Todo 3",
+                        status = TodoState.UNCHECKED,
+                        categoryId = 4,
+                        likes = 5,
+                        targetDate = LocalDate(2025, 8, 27),
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    ),
+                ),
+            ),
+        )
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/UserRepositoryImpl.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/data/repository/UserRepositoryImpl.kt
@@ -21,4 +21,12 @@ class UserRepositoryImpl @Inject constructor(private val userRemoteDataSource: U
             .let { wrapToResource(Dispatchers.IO) { it.data.toUserProfile() } }
         emit(result)
     }.flowOn(Dispatchers.IO)
+
+    override suspend fun getMyUserId(): Flow<Resource<Int>> = flow {
+        emit(Resource.Loading)
+
+        val result =
+            wrapToResource(Dispatchers.IO) { userRemoteDataSource.getUserInfo().data.userId }
+        emit(result)
+    }.flowOn(Dispatchers.IO)
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/di/UseCaseModule.kt
@@ -32,6 +32,7 @@ import com.tico.pomorodo.domain.usecase.todo.DeleteTodoUseCase
 import com.tico.pomorodo.domain.usecase.todo.GetCategoryWithTodoItemsUseCase
 import com.tico.pomorodo.domain.usecase.todo.InsertTodoUseCase
 import com.tico.pomorodo.domain.usecase.todo.UpdateTodoUseCase
+import com.tico.pomorodo.domain.usecase.user.GetMyUserIdUseCase
 import com.tico.pomorodo.domain.usecase.user.GetUserProfileUseCase
 import dagger.Module
 import dagger.Provides
@@ -196,4 +197,9 @@ object UseCaseModule {
     @Provides
     fun provideGetUserProfileUseCase(userRepository: UserRepository): GetUserProfileUseCase =
         GetUserProfileUseCase(userRepository)
+
+    @Singleton
+    @Provides
+    fun provideGetMyUserIdUseCase(userRepository: UserRepository): GetMyUserIdUseCase =
+        GetMyUserIdUseCase(userRepository)
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/model/Follow.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/model/Follow.kt
@@ -1,7 +1,7 @@
 package com.tico.pomorodo.domain.model
 
 data class Follow(
-    val followId: Long,
+    val followId: Int,
     val profileUrl: String? = null,
     val name: String,
     var isFollowing: Boolean

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/UserRepository.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/repository/UserRepository.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     suspend fun getUserProfile(): Flow<Resource<UserProfile>>
+    suspend fun getMyUserId(): Flow<Resource<Int>>
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/user/GetMyUserIdUseCase.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/domain/usecase/user/GetMyUserIdUseCase.kt
@@ -1,0 +1,14 @@
+package com.tico.pomorodo.domain.usecase.user
+
+import com.tico.pomorodo.domain.model.Resource
+import com.tico.pomorodo.domain.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetMyUserIdUseCase @Inject constructor(private val userRepository: UserRepository) {
+    suspend operator fun invoke(): Flow<Resource<Int>> = withContext(Dispatchers.IO) {
+        userRepository.getMyUserId()
+    }
+}

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -54,6 +54,10 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 isOffline = appState.isOffline.value,
                 navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
             )
+            followTodoScreen(
+                navigateToBack = navController::popBackStack,
+                isOffline = appState.isOffline.value,
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
             )
             followScreen(
                 navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -37,7 +37,7 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
         )
         navigation(
             route = MainNavigationDestination.HOME.name,
-            startDestination = BottomNavigationDestination.TODO.name
+            startDestination = BottomNavigationDestination.TIMER.name
         ) {
             timerScreen(
                 setState = { concentrationTime, breakTime ->

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -67,11 +67,7 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             categoryScreen(
                 navigateToAddCategory = navController::navigateToAddCategory,
                 navigateToBack = navController::popBackStack,
-                navigateToInfoCategory = { categoryId ->
-                    navController.navigateToInfoCategory(
-                        categoryId = categoryId
-                    )
-                },
+                navigateToInfoCategory = navController::navigateToInfoCategory,
                 isOffline = appState.isOffline.value
             )
             addCategoryScreen(

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -51,7 +51,9 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 navigateToCategory = navController::navigateToCategory,
                 navigateToAddCategory = navController::navigateToAddCategory,
                 navigateToHistory = navController::navigateToHistory,
-                isOffline = appState.isOffline.value
+                isOffline = appState.isOffline.value,
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
+            )
             )
             followScreen(
                 navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -78,6 +78,8 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             infoCategoryScreen(
                 navigateToBack = navController::popBackStack,
                 isOffline = appState.isOffline.value
+                isOffline = appState.isOffline.value,
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
             )
             groupMemberChooseScreen(
                 navController = navController,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -53,7 +53,14 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 navigateToHistory = navController::navigateToHistory,
                 isOffline = appState.isOffline.value
             )
-            followScreen(navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen)
+            followScreen(
+                navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen,
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
+            )
+            myInfoScreen(
+                navigateToModifyProfile = navController::navigateToModifyProfile,
+                navigateToSettingScreen = navController::navigateToSettingScreen
+            )
             concentrationModeScreen(
                 popBackStack = navController::popBackStack,
                 getState = navController::getState,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -25,7 +25,7 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             navigateToSignUp = navController::navigateToSignUp,
             navigateToHome = navController::navigateToHome,
             onClickedOffline = {
-                navController::navigateToHome
+                navController.navigateToHome()
                 appState.setIsOffline(true)
             },
             isOffline = appState.isOffline.value

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -60,7 +60,10 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             followTodoScreen(
                 navigateToBack = navController::popBackStack,
                 isOffline = appState.isOffline.value,
-                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen,
+                navigateToMyTodoScreen = {
+                    appState.navigateToDestinationReset(BottomNavigationDestination.TODO)
+                }
             )
             followScreen(
                 navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -63,10 +63,6 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 navigateToAddFollowerScreen = navController::navigateToAddFollowerScreen,
                 navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
             )
-            myInfoScreen(
-                navigateToModifyProfile = navController::navigateToModifyProfile,
-                navigateToSettingScreen = navController::navigateToSettingScreen
-            )
             concentrationModeScreen(
                 popBackStack = navController::popBackStack,
                 getState = navController::getState,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -52,7 +52,10 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
                 navigateToAddCategory = navController::navigateToAddCategory,
                 navigateToHistory = navController::navigateToHistory,
                 isOffline = appState.isOffline.value,
-                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen,
+                navigateToMyTodoScreen = {
+                    appState.navigateToDestinationReset(BottomNavigationDestination.TODO)
+                }
             )
             followTodoScreen(
                 navigateToBack = navController::popBackStack,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -113,7 +113,10 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
 
             appThemeScreen(popBackStack = navController::popBackStack)
 
-            addFollowerScreen(popBackToFollowScreen = appState.navController::popBackStack)
+            addFollowerScreen(
+                popBackToFollowScreen = appState.navController::popBackStack,
+                navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
+            )
         }
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -77,7 +77,6 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
             )
             infoCategoryScreen(
                 navigateToBack = navController::popBackStack,
-                isOffline = appState.isOffline.value
                 isOffline = appState.isOffline.value,
                 navigateToFollowTodoScreen = navController::navigateToFollowTodoScreen
             )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -116,6 +116,7 @@ fun NavGraphBuilder.todoScreen(
     navigateToHistory: () -> Unit,
     isOffline: Boolean,
     navigateToFollowTodoScreen: (Int) -> Unit,
+    navigateToMyTodoScreen: () -> Unit,
 ) {
     composable(route = BottomNavigationDestination.TODO.name) {
         BackOnPressed()
@@ -124,7 +125,8 @@ fun NavGraphBuilder.todoScreen(
             navigateToCategory = navigateToCategory,
             navigateToHistory = navigateToHistory,
             isOffline = isOffline,
-            navigateToFollowTodoScreen = navigateToFollowTodoScreen
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen,
+            navigateToMyTodoScreen = navigateToMyTodoScreen
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -126,10 +126,16 @@ fun NavGraphBuilder.todoScreen(
     }
 }
 
-fun NavGraphBuilder.followScreen(navigateToAddFollowerScreen: () -> Unit) {
+fun NavGraphBuilder.followScreen(
+    navigateToAddFollowerScreen: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit
+) {
     composable(route = BottomNavigationDestination.FOLLOW.name) {
         BackOnPressed()
-        FollowListScreen(navigateToAddFollowerScreen)
+        FollowListScreen(
+            navigateToAddFollowerScreen = navigateToAddFollowerScreen,
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen
+        )
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -251,6 +251,7 @@ internal class CategoryArgs(savedStateHandle: SavedStateHandle) {
 fun NavGraphBuilder.infoCategoryScreen(
     navigateToBack: () -> Unit,
     isOffline: Boolean,
+    navigateToFollowTodoScreen: (Int) -> Unit,
 ) {
     composable(
         route = "${MainNavigationDestination.INFO_CATEGORY.name}/{$CATEGORY_ID}",
@@ -259,6 +260,8 @@ fun NavGraphBuilder.infoCategoryScreen(
         CategoryInfoScreenRoute(
             navigateToBack = navigateToBack,
             isOffline = isOffline
+            isOffline = isOffline,
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -82,6 +82,8 @@ fun NavController.navigateToAppThemeScreen(appThemeMode: String) =
 fun NavController.navigateToAddFollowerScreen() =
     navigate(MainNavigationDestination.ADD_FOLLOWER.name)
 
+fun NavController.navigateToFollowTodoScreen(userId: Int) =
+    navigate("${MainNavigationDestination.FOLLOW_TODO.name}/$userId")
 
 // home navigation - composable route
 fun NavGraphBuilder.timerScreen(

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -114,6 +114,7 @@ fun NavGraphBuilder.todoScreen(
     navigateToCategory: () -> Unit,
     navigateToHistory: () -> Unit,
     isOffline: Boolean,
+    navigateToFollowTodoScreen: (Int) -> Unit,
 ) {
     composable(route = BottomNavigationDestination.TODO.name) {
         BackOnPressed()
@@ -121,6 +122,11 @@ fun NavGraphBuilder.todoScreen(
             navigateToAddCategory = navigateToAddCategory,
             navigateToCategory = navigateToCategory,
             navigateToHistory = navigateToHistory,
+            isOffline = isOffline,
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen
+        )
+    }
+}
             isOffline = isOffline
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -134,6 +134,7 @@ fun NavGraphBuilder.todoScreen(
 fun NavGraphBuilder.followTodoScreen(
     navigateToBack: () -> Unit,
     navigateToFollowTodoScreen: (Int) -> Unit,
+    navigateToMyTodoScreen: () -> Unit,
     isOffline: Boolean
 ) {
     composable(
@@ -143,7 +144,8 @@ fun NavGraphBuilder.followTodoScreen(
         FollowTodoScreenRoute(
             navigateToFollowTodoScreen = navigateToFollowTodoScreen,
             navigateToBack = navigateToBack,
-            isOffline = isOffline
+            isOffline = isOffline,
+            navigateToMyTodoScreen = navigateToMyTodoScreen
         )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -99,6 +99,14 @@ fun NavGraphBuilder.timerScreen(
     }
 }
 
+private const val USER_ID = "userId"
+
+internal class UserArgs(savedStateHandle: SavedStateHandle) {
+    val userId: Int = checkNotNull(savedStateHandle[USER_ID]) {
+        "Missing userId"
+    }
+}
+
 fun NavGraphBuilder.todoScreen(
     navigateToAddCategory: () -> Unit,
     navigateToCategory: () -> Unit,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -259,7 +259,6 @@ fun NavGraphBuilder.infoCategoryScreen(
     ) {
         CategoryInfoScreenRoute(
             navigateToBack = navigateToBack,
-            isOffline = isOffline
             isOffline = isOffline,
             navigateToFollowTodoScreen = navigateToFollowTodoScreen
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -349,8 +349,14 @@ fun NavGraphBuilder.appThemeScreen(popBackStack: () -> Unit) {
     }
 }
 
-fun NavGraphBuilder.addFollowerScreen(popBackToFollowScreen: () -> Unit) {
+fun NavGraphBuilder.addFollowerScreen(
+    popBackToFollowScreen: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit
+) {
     composable(route = MainNavigationDestination.ADD_FOLLOWER.name) {
-        AddFollowerScreen(popBackToFollowScreen)
+        AddFollowerScreen(
+            popBackToFollowScreen = popBackToFollowScreen,
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen
+        )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -27,6 +27,7 @@ import com.tico.pomorodo.ui.splash.view.SplashScreen
 import com.tico.pomorodo.ui.timer.running.view.BreakTimerScreen
 import com.tico.pomorodo.ui.timer.running.view.ConcentrationTimerScreen
 import com.tico.pomorodo.ui.timer.setup.view.TimerRootScreen
+import com.tico.pomorodo.ui.todo.view.FollowTodoScreenRoute
 import com.tico.pomorodo.ui.todo.view.TodoScreenRoute
 
 // home navigation - navigate
@@ -127,6 +128,19 @@ fun NavGraphBuilder.todoScreen(
         )
     }
 }
+
+fun NavGraphBuilder.followTodoScreen(
+    navigateToBack: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit,
+    isOffline: Boolean
+) {
+    composable(
+        route = "${MainNavigationDestination.FOLLOW_TODO.name}/{$USER_ID}",
+        arguments = listOf(navArgument(name = USER_ID) { type = NavType.IntType })
+    ) {
+        FollowTodoScreenRoute(
+            navigateToFollowTodoScreen = navigateToFollowTodoScreen,
+            navigateToBack = navigateToBack,
             isOffline = isOffline
         )
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/NavigationDestination.kt
@@ -54,4 +54,6 @@ enum class MainNavigationDestination {
     APP_THEME,
 
     ADD_FOLLOWER,
+
+    FOLLOW_TODO
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/MainScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.tico.pomorodo.R
 import com.tico.pomorodo.navigation.AppNavHost
 import com.tico.pomorodo.navigation.BottomNavigationDestination
+import com.tico.pomorodo.navigation.MainNavigationDestination
 import com.tico.pomorodo.ui.common.view.executeToast
 import com.tico.pomorodo.ui.home.view.BottomBar
 import com.tico.pomorodo.ui.home.view.rememberAppState
@@ -34,7 +35,9 @@ fun MainScreen() {
     val currentRoute = appState.currentDestination?.route
 
     LaunchedEffect(appState.isOffline.value, currentRoute) {
-        val isNowFollow = currentRoute == BottomNavigationDestination.FOLLOW.name
+        val isNowFollow =
+            currentRoute?.startsWith(BottomNavigationDestination.FOLLOW.name) == true ||
+                    currentRoute?.startsWith(MainNavigationDestination.FOLLOW_TODO.name) == true
         if (appState.isOffline.value && isNowFollow) {
             appState.navigateToDestination(BottomNavigationDestination.TIMER)
         }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -53,7 +53,8 @@ import kotlinx.coroutines.launch
 fun CategoryInfoScreenRoute(
     viewModel: CategoryInfoViewModel = hiltViewModel(),
     navigateToBack: () -> Unit,
-    isOffline: Boolean
+    isOffline: Boolean,
+    navigateToFollowTodoScreen: (Int) -> Unit
 ) {
     val openSettingsOptionSheetState = rememberModalBottomSheetState()
     val checkGroupMemberSheetState = rememberModalBottomSheetState()
@@ -119,7 +120,10 @@ fun CategoryInfoScreenRoute(
                         sheetState = checkGroupMemberSheetState,
                         onShowBottomSheetChange = { showCheckGroupMemberBottomSheet = it },
                         memberList = user,
-                        onClicked = {}
+                        onClicked = { userId ->
+                            showCheckGroupMemberBottomSheet = false
+                            navigateToFollowTodoScreen(userId)
+                        }
                     )
                 }
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CheckGroupMemberBottomSheet.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CheckGroupMemberBottomSheet.kt
@@ -34,7 +34,7 @@ fun CheckGroupMemberBottomSheet(
     sheetState: SheetState,
     onShowBottomSheetChange: (Boolean) -> Unit,
     memberList: List<User>,
-    onClicked: () -> Unit
+    onClicked: (Int) -> Unit
 ) {
     ModalBottomSheet(
         onDismissRequest = {
@@ -74,7 +74,7 @@ fun CheckGroupMemberBottomSheet(
                         size = 36,
                         name = it.name,
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
-                        onClicked = onClicked
+                        onClicked = { onClicked(it.id) }
                     )
                 }
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryInfoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/viewModel/CategoryInfoViewModel.kt
@@ -41,7 +41,7 @@ class CategoryInfoViewModel @Inject constructor(
     val selectedGroupMembers: StateFlow<List<SelectedUser>>
         get() = _selectedGroupMembers.asStateFlow()
 
-    private var follower = MutableStateFlow<List<User>?>(null)
+    private val follower = MutableStateFlow<List<User>?>(null)
 
     init {
         loadData()

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Profile.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/common/view/Profile.kt
@@ -111,10 +111,11 @@ fun ProfileHorizontal(
     defaultProfileUri: String? = null,
     name: String,
     textStyle: TextStyle,
+    isClicked: Boolean = true,
     onClicked: () -> Unit = {}
 ) {
     Row(
-        modifier = modifier.clickableWithoutRipple { onClicked() },
+        modifier = modifier.clickableWithoutRipple(isClicked) { onClicked() },
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
@@ -28,7 +28,7 @@ import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
 import com.tico.pomorodo.ui.common.view.SimpleIconButton
 import com.tico.pomorodo.ui.common.view.SimpleText
-import com.tico.pomorodo.ui.member.viewmodel.FollowViewModel
+import com.tico.pomorodo.ui.follow.viewmodel.FollowViewModel
 import com.tico.pomorodo.ui.theme.IC_ALL_CLEAN
 import com.tico.pomorodo.ui.theme.IC_SEARCH
 import com.tico.pomorodo.ui.theme.PomoroDoTheme

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
@@ -34,7 +34,10 @@ import com.tico.pomorodo.ui.theme.IC_SEARCH
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
-fun AddFollowerScreen(popBackToFollowScreen: () -> Unit) {
+fun AddFollowerScreen(
+    popBackToFollowScreen: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit
+) {
     val followViewModel: FollowViewModel = hiltViewModel()
     val followingList by followViewModel.followingList.collectAsState()
     var unFollowingDialogVisible by remember { mutableStateOf(false) }
@@ -112,7 +115,8 @@ fun AddFollowerScreen(popBackToFollowScreen: () -> Unit) {
                 } else {
                     followViewModel.toggleFollowState(index)
                 }
-            }
+            },
+            onProfileClicked = navigateToFollowTodoScreen
         )
     }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
@@ -39,13 +39,17 @@ import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.Profile
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
+import com.tico.pomorodo.ui.common.view.clickableWithoutRipple
 import com.tico.pomorodo.ui.follow.viewmodel.FollowViewModel
 import com.tico.pomorodo.ui.theme.IC_ADD_CATEGORY
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import kotlinx.coroutines.launch
 
 @Composable
-fun FollowListScreen(navigateToAddFollowerScreen: () -> Unit) {
+fun FollowListScreen(
+    navigateToAddFollowerScreen: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit
+) {
     val followViewModel: FollowViewModel = hiltViewModel()
     val followerList by followViewModel.followerList.collectAsState()
     val followingList by followViewModel.followingList.collectAsState()
@@ -78,14 +82,16 @@ fun FollowListScreen(navigateToAddFollowerScreen: () -> Unit) {
                     } else {
                         followViewModel.toggleFollowState(index)
                     }
-                }
+                },
+                onProfileClicked = navigateToFollowTodoScreen
             )
             else FollowerList(
                 followList = followerList,
                 onClick = { index ->
                     selectedIndex = index
                     removeFollowerDialogVisible = true
-                }
+                },
+                onProfileClicked = navigateToFollowTodoScreen
             )
         }
     }
@@ -176,7 +182,11 @@ fun FollowTabRow(selectedTabIndex: Int, onSelectedTabIndexChange: (Int) -> Unit)
 }
 
 @Composable
-fun FollowingList(followList: List<Follow>, onClick: (Int, Boolean) -> Unit) {
+fun FollowingList(
+    followList: List<Follow>,
+    onClick: (Int, Boolean) -> Unit,
+    onProfileClicked: (Int) -> Unit
+) {
     LazyColumn(
         modifier = Modifier
             .padding(horizontal = 18.dp)
@@ -195,14 +205,19 @@ fun FollowingList(followList: List<Follow>, onClick: (Int, Boolean) -> Unit) {
                 followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
                 unFollowButtonContainerColor = PomoroDoTheme.colorScheme.primaryContainer,
                 unFollowButtonContentColor = Color.White,
-                onClick = { onClick(index, user.isFollowing) }
+                onClick = { onClick(index, user.isFollowing) },
+                onProfileClicked = onProfileClicked
             )
         }
     }
 }
 
 @Composable
-fun FollowerList(followList: List<Follow>, onClick: (Int) -> Unit) {
+fun FollowerList(
+    followList: List<Follow>,
+    onClick: (Int) -> Unit,
+    onProfileClicked: (Int) -> Unit
+) {
     LazyColumn(
         modifier = Modifier
             .padding(top = 18.dp, start = 18.dp, end = 18.dp)
@@ -215,7 +230,8 @@ fun FollowerList(followList: List<Follow>, onClick: (Int) -> Unit) {
                 followButtonText = stringResource(id = R.string.content_delete),
                 followButtonContainerColor = PomoroDoTheme.colorScheme.gray90,
                 followButtonContentColor = PomoroDoTheme.colorScheme.gray20,
-                onClick = { onClick(index) }
+                onClick = { onClick(index) },
+                onProfileClicked = onProfileClicked
             )
         }
     }
@@ -230,7 +246,8 @@ fun FollowItem(
     followButtonContentColor: Color,
     unFollowButtonContainerColor: Color? = null,
     unFollowButtonContentColor: Color? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onProfileClicked: (Int) -> Unit = {}
 ) {
     val buttonText =
         if (user.isFollowing) followButtonText
@@ -247,18 +264,20 @@ fun FollowItem(
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Profile(size = 40, uri = user.profileUrl)
+        Row(
+            modifier = Modifier.weight(1f).clickableWithoutRipple { onProfileClicked(user.followId) },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Profile(size = 40, uri = user.profileUrl)
 
-        Text(
-            text = user.name,
-            modifier = Modifier.padding(start = 16.dp),
-            color = PomoroDoTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Start,
-            style = PomoroDoTheme.typography.laundryGothicRegular16
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
+            Text(
+                text = user.name,
+                modifier = Modifier.padding(start = 16.dp),
+                color = PomoroDoTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Start,
+                style = PomoroDoTheme.typography.laundryGothicRegular16
+            )
+        }
         CustomTextButton(
             text = buttonText,
             containerColor = buttonContainerColor,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/FollowScreen.kt
@@ -39,7 +39,7 @@ import com.tico.pomorodo.ui.common.view.CustomTextButton
 import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.common.view.Profile
 import com.tico.pomorodo.ui.common.view.SimpleAlertDialog
-import com.tico.pomorodo.ui.member.viewmodel.FollowViewModel
+import com.tico.pomorodo.ui.follow.viewmodel.FollowViewModel
 import com.tico.pomorodo.ui.theme.IC_ADD_CATEGORY
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 import kotlinx.coroutines.launch

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/viewmodel/FollowViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/viewmodel/FollowViewModel.kt
@@ -1,7 +1,7 @@
-package com.tico.pomorodo.ui.member.viewmodel
+package com.tico.pomorodo.ui.follow.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.tico.pomorodo.data.local.datasource.DataSource.followList
+import com.tico.pomorodo.data.local.datasource.DataSource
 import com.tico.pomorodo.domain.model.Follow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,10 +10,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FollowViewModel @Inject constructor() : ViewModel() {
-    private val _followingList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
+    private val _followingList: MutableStateFlow<List<Follow>> =
+        MutableStateFlow(DataSource.followList)
     val followingList: StateFlow<List<Follow>> = _followingList
 
-    private val _followerList: MutableStateFlow<List<Follow>> = MutableStateFlow(followList)
+    private val _followerList: MutableStateFlow<List<Follow>> =
+        MutableStateFlow(DataSource.followList)
     val followerList: StateFlow<List<Follow>> = _followerList
 
     fun toggleFollowState(index: Int) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/home/view/AppState.kt
@@ -67,12 +67,28 @@ data class AppState(
             launchSingleTop = true
             restoreState = true
         }
-
         when (topLevelDestination) {
             BottomNavigationDestination.TIMER -> navController.navigateToTimer(navOptions)
             BottomNavigationDestination.TODO -> navController.navigateToTodo(navOptions)
             BottomNavigationDestination.FOLLOW -> navController.navigateToFollow(navOptions)
             BottomNavigationDestination.MY_INFO -> navController.navigateToMyInfo(navOptions)
+        }
+    }
+
+    fun navigateToDestinationReset(topLevelDestination: BottomNavigationDestination) {
+        val resetOptions = navOptions {
+            popUpTo(MainNavigationDestination.HOME.name) {
+                inclusive = false
+                saveState = false
+            }
+            launchSingleTop = true
+            restoreState = false
+        }
+        when (topLevelDestination) {
+            BottomNavigationDestination.TIMER -> navController.navigateToTimer(resetOptions)
+            BottomNavigationDestination.TODO -> navController.navigateToTodo(resetOptions)
+            BottomNavigationDestination.FOLLOW -> navController.navigateToFollow(resetOptions)
+            BottomNavigationDestination.MY_INFO -> navController.navigateToMyInfo(resetOptions)
         }
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
@@ -33,7 +33,7 @@ import kotlinx.datetime.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FriendTodoScreenRoute(
+fun FollowTodoScreenRoute(
     viewModel: FriendTodoViewModel = hiltViewModel(),
     navigateToBack: () -> Unit
 ) {
@@ -74,7 +74,7 @@ fun FriendTodoScreenRoute(
                         )
                     }
                 }
-                FriendTodoScreen(
+                FollowTodoScreen(
                     user = friendUser,
                     onButtonClicked = viewModel::setFollowing,
                     selectedDate = selectedDate,
@@ -96,7 +96,7 @@ fun FriendTodoScreenRoute(
 }
 
 @Composable
-fun FriendTodoScreen(
+fun FollowTodoScreen(
     user: Follow,
     onButtonClicked: () -> Unit,
     onGroupIconClicked: (TodoData) -> Unit,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
@@ -36,6 +36,7 @@ import kotlinx.datetime.LocalDate
 fun FollowTodoScreenRoute(
     viewModel: FollowTodoViewModel = hiltViewModel(),
     navigateToFollowTodoScreen: (Int) -> Unit,
+    navigateToMyTodoScreen: () -> Unit,
     navigateToBack: () -> Unit,
     isOffline: Boolean
 ) {
@@ -75,7 +76,11 @@ fun FollowTodoScreenRoute(
                             isClicked = !isOffline,
                             onClicked = { userId ->
                                 showGroupBottomSheet = false
-                                navigateToFollowTodoScreen(userId)
+                                if(viewModel.isMyProfile(userId)){
+                                    navigateToMyTodoScreen()
+                                }else{
+                                    navigateToFollowTodoScreen(userId)
+                                }
                             }
                         )
                     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
@@ -35,7 +35,9 @@ import kotlinx.datetime.LocalDate
 @Composable
 fun FollowTodoScreenRoute(
     viewModel: FollowTodoViewModel = hiltViewModel(),
-    navigateToBack: () -> Unit
+    navigateToFollowTodoScreen: (Int) -> Unit,
+    navigateToBack: () -> Unit,
+    isOffline: Boolean
 ) {
     val sheetState = rememberModalBottomSheetState()
     val user by viewModel.user.collectAsState()
@@ -70,7 +72,11 @@ fun FollowTodoScreenRoute(
                             incompletedList = todoItem.incompletedList ?: listOf(),
                             totalNumber = (todoItem.completedList?.size ?: 0)
                                     + (todoItem.incompletedList?.size ?: 0),
-                            onClicked = {}
+                            isClicked = !isOffline,
+                            onClicked = { userId ->
+                                showGroupBottomSheet = false
+                                navigateToFollowTodoScreen(userId)
+                            }
                         )
                     }
                 }
@@ -87,7 +93,7 @@ fun FollowTodoScreenRoute(
                         selectedTodoItem = todoItem
                         showGroupBottomSheet = true
                     },
-                    onLikedIconClicked = viewModel::updateTodoLicked,
+                    onLikedIconClicked = viewModel::updateTodoLiked,
                     calendarDates = calendarDates,
                 )
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/FollowTodoScreen.kt
@@ -28,13 +28,13 @@ import com.tico.pomorodo.domain.model.Follow
 import com.tico.pomorodo.ui.common.view.CustomTopAppBar
 import com.tico.pomorodo.ui.follow.view.FollowItem
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
-import com.tico.pomorodo.ui.todo.viewmodel.FriendTodoViewModel
+import com.tico.pomorodo.ui.todo.viewmodel.FollowTodoViewModel
 import kotlinx.datetime.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FollowTodoScreenRoute(
-    viewModel: FriendTodoViewModel = hiltViewModel(),
+    viewModel: FollowTodoViewModel = hiltViewModel(),
     navigateToBack: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState()

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/GroupBottomSheet.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/GroupBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,7 +35,8 @@ fun GroupBottomSheet(
     completedList: List<User>,
     incompletedList: List<User>,
     totalNumber: Int,
-    onClicked: () -> Unit
+    isClicked: Boolean,
+    onClicked: (Int) -> Unit
 ) {
     ModalBottomSheet(
         onDismissRequest = {
@@ -76,13 +78,21 @@ fun GroupBottomSheet(
                     )
                     Spacer(modifier = Modifier.height(6.dp))
                 }
-                items(completedList) {
-                    ProfileHorizontal(
-                        size = 36,
-                        name = it.name,
-                        textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
-                        onClicked = onClicked
-                    )
+                if (completedList.isEmpty()) {
+                    item {
+                        Spacer(modifier = Modifier.height(10.dp))
+                    }
+                } else {
+                    items(completedList) { user ->
+                        ProfileHorizontal(
+                            modifier = Modifier.fillMaxWidth(),
+                            size = 36,
+                            name = user.name,
+                            textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
+                            isClicked = isClicked,
+                            onClicked = { onClicked(user.id) }
+                        )
+                    }
                 }
                 item {
                     Spacer(modifier = Modifier.height(6.dp))
@@ -102,13 +112,21 @@ fun GroupBottomSheet(
                     )
                     Spacer(modifier = Modifier.height(6.dp))
                 }
-                items(incompletedList) {
-                    ProfileHorizontal(
-                        size = 36,
-                        name = it.name,
-                        textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
-                        onClicked = onClicked
-                    )
+                if (incompletedList.isEmpty()) {
+                    item {
+                        Spacer(modifier = Modifier.height(10.dp))
+                    }
+                } else {
+                    items(incompletedList) { user ->
+                        ProfileHorizontal(
+                            modifier = Modifier.fillMaxWidth(),
+                            size = 36,
+                            name = user.name,
+                            textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
+                            isClicked = isClicked,
+                            onClicked = { onClicked(user.id) }
+                        )
+                    }
                 }
                 item {
                     Spacer(modifier = Modifier.height(10.dp))

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoListScreen.kt
@@ -192,7 +192,7 @@ fun TodoMake(
 fun TodoListItem(
     todoData: TodoData,
     isFriend: Boolean,
-    isGroup: Boolean,
+    isGroupTodo: Boolean,
     isEditMode: Boolean = false,
     isLikedClick: Boolean,
     updatedTodoItemTitle: String,
@@ -229,7 +229,7 @@ fun TodoListItem(
             )
         }
 
-        if (isGroup && !isFriend && !isOffline) {
+        if (isGroupTodo && !isOffline) {
             TodoGroupButton(
                 groupNumber = todoData.completedList?.size ?: 0,
                 onGroupClicked = onGroupIconClicked
@@ -245,7 +245,7 @@ fun TodoListItem(
             )
         }
 
-        if (!isFriend && (!isOffline || !isGroup)) {
+        if (!isFriend && (!isOffline || !isGroupTodo)) {
             MoreInfoButton(
                 showMoreInfo = showDropDownMoreInfo,
                 onShowMoreInfoChange = { showDropDownMoreInfo = it },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
@@ -40,7 +40,8 @@ fun TodoScreenRoute(
     navigateToCategory: () -> Unit,
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
-    navigateToFollowTodoScreen: (Int) -> Unit
+    navigateToFollowTodoScreen: (Int) -> Unit,
+    navigateToMyTodoScreen: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     val sheetState = rememberModalBottomSheetState()
@@ -104,7 +105,11 @@ fun TodoScreenRoute(
                         isClicked = !isOffline,
                         onClicked = { userId ->
                             showGroupBottomSheet = false
-                            navigateToFollowTodoScreen(userId)
+                            if(viewModel.isMyUserId(userId)){
+                                navigateToMyTodoScreen()
+                            }else{
+                                navigateToFollowTodoScreen(userId)
+                            }
                         }
                     )
                 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
@@ -271,7 +271,8 @@ fun CategorySection(
                 onUpdatedTodoItemTitle = onUpdatedTodoItemTitle,
                 isEditMode = !isNewTodoMakeVisible && categoryIndex == selectedCategoryIndex,
                 isFriend = isFriend,
-                onLikedIconClicked = onLikedIconClicked
+                onLikedIconClicked = onLikedIconClicked,
+                isGroupCategory = category.type == CategoryType.GROUP
             )
         }
     }
@@ -297,13 +298,14 @@ fun CategoryWithTodoItems(
     onGroupIconClicked: (TodoData) -> Unit,
     onUpdateTodoItem: () -> Unit,
     isOffline: Boolean,
+    isGroupCategory: Boolean
 ) {
     CategoryTag(
         title = categoryWithTodoItem.title,
         groupMemberCount = categoryWithTodoItem.groupMemberCount,
         onAddClicked = onClickedCategoryTag,
-        isAddButton = (!isFriend && !isOffline) || categoryWithTodoItem.type != CategoryType.GROUP,
-        enabled = (!isFriend && !isOffline) || categoryWithTodoItem.type != CategoryType.GROUP
+        isAddButton = (!isFriend && !isOffline) || (isOffline && !isGroupCategory),
+        enabled = (!isFriend && !isOffline) || (isOffline && !isGroupCategory)
     )
     Spacer(modifier = Modifier.height(10.dp))
     if (isNewTodoMakeVisible) {
@@ -319,7 +321,7 @@ fun CategoryWithTodoItems(
             TodoListItem(
                 isOffline = isOffline,
                 todoData = todoData,
-                isGroup = categoryWithTodoItem.groupMemberCount > 0,
+                isGroupTodo = isGroupCategory,
                 onStateChanged = {
                     onTodoStateChanged(todoData)
                 },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/view/TodoScreen.kt
@@ -40,6 +40,7 @@ fun TodoScreenRoute(
     navigateToCategory: () -> Unit,
     navigateToAddCategory: () -> Unit,
     navigateToHistory: () -> Unit,
+    navigateToFollowTodoScreen: (Int) -> Unit
 ) {
     val focusManager = LocalFocusManager.current
     val sheetState = rememberModalBottomSheetState()
@@ -100,7 +101,11 @@ fun TodoScreenRoute(
                         incompletedList = todoItem.incompletedList ?: listOf(),
                         totalNumber = (todoItem.completedList?.size ?: 0)
                                 + (todoItem.incompletedList?.size ?: 0),
-                        onClicked = {}
+                        isClicked = !isOffline,
+                        onClicked = { userId ->
+                            showGroupBottomSheet = false
+                            navigateToFollowTodoScreen(userId)
+                        }
                     )
                 }
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
@@ -35,9 +35,7 @@ class FollowTodoViewModel @Inject constructor(
     val categoryWithTodoItemList: StateFlow<List<CategoryWithTodoItem>>
         get() = _categoryWithTodoItemList.asStateFlow()
 
-    private var _myUserId = MutableStateFlow<Int>(-1)
-    val myUserId: StateFlow<Int>
-        get() = _myUserId.asStateFlow()
+    private val myUserId = MutableStateFlow<Int>(-1)
 
     private var _user = MutableStateFlow<Follow?>(null)
     val user: StateFlow<Follow?>
@@ -88,7 +86,7 @@ class FollowTodoViewModel @Inject constructor(
                 }
 
                 is Resource.Success -> {
-                    _myUserId.value = result.data
+                    myUserId.value = result.data
                 }
 
                 is Resource.Failure.Exception -> {
@@ -126,6 +124,6 @@ class FollowTodoViewModel @Inject constructor(
     }
 
     fun isMyProfile(userId: Int): Boolean {
-        return _myUserId.value == userId
+        return myUserId.value == userId
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
@@ -124,4 +124,8 @@ class FollowTodoViewModel @Inject constructor(
     private fun getCategoryWithTodoItems(userId: Int) {
         // TODO: 친구의 카테고리 별 투두 불러오는 로직
     }
+
+    fun isMyProfile(userId: Int): Boolean {
+        return _myUserId.value == userId
+    }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
@@ -16,7 +16,9 @@ import kotlinx.datetime.toLocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class FriendTodoViewModel @Inject constructor() : ViewModel() {
+class FollowTodoViewModel @Inject constructor() : ViewModel() {
+
+    private val args = UserArgs(saveStateHandle)
 
     private var _categoryWithTodoItemList =
         MutableStateFlow<List<CategoryWithTodoItem>>(emptyList())

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
@@ -1,9 +1,11 @@
 package com.tico.pomorodo.ui.todo.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.tico.pomorodo.data.model.CalendarDate
 import com.tico.pomorodo.data.model.CategoryWithTodoItem
 import com.tico.pomorodo.domain.model.Follow
+import com.tico.pomorodo.navigation.UserArgs
 import com.tico.pomorodo.ui.common.view.toTimeZoneOf5AM
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +18,7 @@ import kotlinx.datetime.toLocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class FollowTodoViewModel @Inject constructor() : ViewModel() {
+class FollowTodoViewModel @Inject constructor(saveStateHandle: SavedStateHandle) : ViewModel() {
 
     private val args = UserArgs(saveStateHandle)
 
@@ -57,15 +59,19 @@ class FollowTodoViewModel @Inject constructor() : ViewModel() {
         get() = _isLoading.asStateFlow()
 
     init {
-        fetchFollowing()
-        getCategoryWithTodoItems()
+        loadData()
+    }
+
+    private fun loadData() {
+        fetchFollowInfo(args.userId)
+        getCategoryWithTodoItems(args.userId)
     }
 
     fun setSelectedDate(date: LocalDate) {
         _selectedDate.value = date
     }
 
-    private fun fetchFollowing() {
+    private fun fetchFollowInfo(userId: Int) {
         // TODO: follower user 정보 불러오는 로직 구현
     }
 
@@ -73,11 +79,11 @@ class FollowTodoViewModel @Inject constructor() : ViewModel() {
         // TODO: follow/following 버튼 클릭 로직 구현
     }
 
-    fun updateTodoLicked(todoId: Int) {
+    fun updateTodoLiked(todoId: Int) {
         // TODO: 좋아요 로직 구현
     }
 
-    private fun getCategoryWithTodoItems() {
+    private fun getCategoryWithTodoItems(userId: Int) {
         // TODO: 친구의 카테고리 별 투두 불러오는 로직
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/FollowTodoViewModel.kt
@@ -1,16 +1,21 @@
 package com.tico.pomorodo.ui.todo.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.tico.pomorodo.data.model.CalendarDate
 import com.tico.pomorodo.data.model.CategoryWithTodoItem
 import com.tico.pomorodo.domain.model.Follow
+import com.tico.pomorodo.domain.model.Resource
+import com.tico.pomorodo.domain.usecase.user.GetMyUserIdUseCase
 import com.tico.pomorodo.navigation.UserArgs
 import com.tico.pomorodo.ui.common.view.toTimeZoneOf5AM
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -18,7 +23,10 @@ import kotlinx.datetime.toLocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class FollowTodoViewModel @Inject constructor(saveStateHandle: SavedStateHandle) : ViewModel() {
+class FollowTodoViewModel @Inject constructor(
+    saveStateHandle: SavedStateHandle,
+    private val getMyUserIdUseCase: GetMyUserIdUseCase
+) : ViewModel() {
 
     private val args = UserArgs(saveStateHandle)
 
@@ -26,6 +34,10 @@ class FollowTodoViewModel @Inject constructor(saveStateHandle: SavedStateHandle)
         MutableStateFlow<List<CategoryWithTodoItem>>(emptyList())
     val categoryWithTodoItemList: StateFlow<List<CategoryWithTodoItem>>
         get() = _categoryWithTodoItemList.asStateFlow()
+
+    private var _myUserId = MutableStateFlow<Int>(-1)
+    val myUserId: StateFlow<Int>
+        get() = _myUserId.asStateFlow()
 
     private var _user = MutableStateFlow<Follow?>(null)
     val user: StateFlow<Follow?>
@@ -65,6 +77,32 @@ class FollowTodoViewModel @Inject constructor(saveStateHandle: SavedStateHandle)
     private fun loadData() {
         fetchFollowInfo(args.userId)
         getCategoryWithTodoItems(args.userId)
+        getMyUserId()
+    }
+
+    private fun getMyUserId() = viewModelScope.launch {
+        getMyUserIdUseCase().collect { result ->
+            when (result) {
+                is Resource.Loading -> {
+
+                }
+
+                is Resource.Success -> {
+                    _myUserId.value = result.data
+                }
+
+                is Resource.Failure.Exception -> {
+                    Log.e("FollowTodoViewModel", "getMyUserId: ${result.message}")
+                }
+
+                is Resource.Failure.Error -> {
+                    Log.e(
+                        "FollowTodoViewModel",
+                        "getMyUserId: ${result.code} ${result.message}"
+                    )
+                }
+            }
+        }
     }
 
     fun setSelectedDate(date: LocalDate) {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
@@ -44,9 +44,7 @@ class TodoViewModel @Inject constructor(
     private val getMyUserIdUseCase: GetMyUserIdUseCase
 ) : ViewModel() {
 
-    private var _myUserId = MutableStateFlow<Int>(-1)
-    val myUserId: StateFlow<Int?>
-        get() = _myUserId.asStateFlow()
+    private val myUserId = MutableStateFlow<Int>(-1)
 
     private var _categoryWithTodoItemList =
         MutableStateFlow<List<CategoryWithTodoItem>>(emptyList())
@@ -92,7 +90,7 @@ class TodoViewModel @Inject constructor(
                 is Resource.Loading -> {}
 
                 is Resource.Success -> {
-                    _myUserId.value = result.data
+                    myUserId.value = result.data
                 }
 
                 is Resource.Failure.Exception -> {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
@@ -15,6 +15,7 @@ import com.tico.pomorodo.domain.usecase.todo.DeleteTodoUseCase
 import com.tico.pomorodo.domain.usecase.todo.GetCategoryWithTodoItemsUseCase
 import com.tico.pomorodo.domain.usecase.todo.InsertTodoUseCase
 import com.tico.pomorodo.domain.usecase.todo.UpdateTodoUseCase
+import com.tico.pomorodo.domain.usecase.user.GetMyUserIdUseCase
 import com.tico.pomorodo.ui.common.view.atEndOfMonth
 import com.tico.pomorodo.ui.common.view.atStartOfMonth
 import com.tico.pomorodo.ui.common.view.toTimeZoneOf5AM
@@ -40,7 +41,12 @@ class TodoViewModel @Inject constructor(
     private val getCalendarDateForMonthUseCase: GetCalendarDateForMonthUseCase,
     private val insertCalendarDateForMonthUseCase: InsertCalendarDateForMonthUseCase,
     private val updateCalendarDateForMonthUseCase: UpdateCalendarDateForMonthUseCase,
+    private val getMyUserIdUseCase: GetMyUserIdUseCase
 ) : ViewModel() {
+
+    private var _myUserId = MutableStateFlow<Int>(-1)
+    val myUserId: StateFlow<Int?>
+        get() = _myUserId.asStateFlow()
 
     private var _categoryWithTodoItemList =
         MutableStateFlow<List<CategoryWithTodoItem>>(emptyList())
@@ -75,8 +81,32 @@ class TodoViewModel @Inject constructor(
         get() = _isLoading.asStateFlow()
 
     init {
+        getMyUserId()
         getCategoryWithTodoItems()
         getCalendarDates()
+    }
+
+    private fun getMyUserId() = viewModelScope.launch {
+        getMyUserIdUseCase().collect { result ->
+            when (result) {
+                is Resource.Loading -> {}
+
+                is Resource.Success -> {
+                    _myUserId.value = result.data
+                }
+
+                is Resource.Failure.Exception -> {
+                    Log.e("TodoViewModel", "getMyUserId: ${result.message}")
+                }
+
+                is Resource.Failure.Error -> {
+                    Log.e(
+                        "TodoViewModel",
+                        "getMyUserId: ${result.code} ${result.message}"
+                    )
+                }
+            }
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/todo/viewmodel/TodoViewModel.kt
@@ -240,4 +240,8 @@ class TodoViewModel @Inject constructor(
             deleteTodoUseCase(todoId)
         }
     }
+
+    fun isMyUserId(userId: Int): Boolean {
+        return myUserId.value == userId
+    }
 }


### PR DESCRIPTION
1. followViewModel을 member 패키지에서 follow 패키지로 이동
2. FriendTodoScreen을 FollowTodoScreen으로 이름 변경
3. Follow 모델의 followId의 데이터 타입을 Long에서 Int로 변경
4. 그룹원 프로필 또는 팔로우 프로필 클릭 시, 해당 유저의 팔로우 투두 리스트로 이동하는 로직 추가
   (단, 해당 유저가 '나'일 경우 홈화면의 투두로 이동)