### PR TITLE
[FEAT] 네트워크 연결이 안될 때, 스플래쉬 화면 이동 (TICO-447)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavHost.kt
@@ -17,6 +17,7 @@ fun AppNavHost(modifier: Modifier = Modifier, appState: AppState) {
         modifier = modifier
     ) {
         splashScreen(
+            isNetworkConnected = appState.isNetworkConnected.value,
             navigateToLogin = navController::navigateToLogIn,
             navigateToHome = navController::navigateToHome
         )

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/navigation/AppNavigation.kt
@@ -171,9 +171,17 @@ fun NavGraphBuilder.myInfoScreen(navigateToSettingScreen: () -> Unit) {
 }
 
 // main navigation - composable route
-fun NavGraphBuilder.splashScreen(navigateToLogin: () -> Unit, navigateToHome: () -> Unit) {
+fun NavGraphBuilder.splashScreen(
+    navigateToLogin: () -> Unit,
+    navigateToHome: () -> Unit,
+    isNetworkConnected: Boolean
+) {
     composable(route = MainNavigationDestination.SPLASH.name) {
-        SplashScreen(navigateToLogin = navigateToLogin, navigateToHome = navigateToHome)
+        SplashScreen(
+            navigateToLogin = navigateToLogin,
+            navigateToHome = navigateToHome,
+            isNetworkConnected = isNetworkConnected
+        )
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthState.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/auth/viewModel/AuthState.kt
@@ -1,5 +1,5 @@
 package com.tico.pomorodo.ui.auth.viewModel
 
 enum class AuthState {
-    LOADING, NEED_LOGIN, SUCCESS_LOGIN, NEED_JOIN, SUCCESS_JOIN
+    LOADING, NEED_LOGIN, SUCCESS_LOGIN, NEED_JOIN, SUCCESS_JOIN, OFFLINE
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
@@ -41,7 +41,7 @@ fun SplashScreen(
                 navigateToHome()
             }
 
-            AuthState.NEED_LOGIN -> {
+            AuthState.NEED_LOGIN, AuthState.OFFLINE -> {
                 delay(3000)
                 navigateToLogin()
             }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.delay
 fun SplashScreen(
     viewModel: SplashViewModel = hiltViewModel(),
     navigateToLogin: () -> Unit,
-    navigateToHome: () -> Unit
+    navigateToHome: () -> Unit,
+    isNetworkConnected: Boolean
 ) {
     val authState by viewModel.authState.collectAsState()
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/view/SplashScreen.kt
@@ -30,6 +30,10 @@ fun SplashScreen(
 ) {
     val authState by viewModel.authState.collectAsState()
 
+    LaunchedEffect(Unit) {
+        viewModel.attemptAutoLogin(isNetworkConnected)
+    }
+
     LaunchedEffect(authState) {
         when (authState) {
             AuthState.SUCCESS_LOGIN -> {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/viewModel/SplashViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/viewModel/SplashViewModel.kt
@@ -31,10 +31,6 @@ class SplashViewModel @Inject constructor(
     val authState: StateFlow<AuthState>
         get() = _authState.asStateFlow()
 
-    private var _isLoading = MutableStateFlow<Boolean>(true)
-    val isLoading: StateFlow<Boolean>
-        get() = _isLoading.asStateFlow()
-
     init {
         fetchIsAccessToken()
     }
@@ -53,11 +49,10 @@ class SplashViewModel @Inject constructor(
             when (result) {
                 is Resource.Success -> {
                     _authState.value = AuthState.SUCCESS_LOGIN
-                    _isLoading.value = false
                 }
 
                 is Resource.Loading -> {
-                    _isLoading.value = true
+                    _authState.value = AuthState.LOADING
                 }
 
                 is Resource.Failure.Error -> {
@@ -81,11 +76,10 @@ class SplashViewModel @Inject constructor(
                     saveRefreshToken(result.data.data.refreshToken)
                     saveAccessToken(result.data.data.accessToken)
                     _authState.value = AuthState.SUCCESS_LOGIN
-                    _isLoading.value = false
                 }
 
                 is Resource.Loading -> {
-                    _isLoading.value = true
+                    _authState.value = AuthState.LOADING
                 }
 
                 is Resource.Failure.Error -> {

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/viewModel/SplashViewModel.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/splash/viewModel/SplashViewModel.kt
@@ -31,8 +31,12 @@ class SplashViewModel @Inject constructor(
     val authState: StateFlow<AuthState>
         get() = _authState.asStateFlow()
 
-    init {
-        fetchIsAccessToken()
+    fun attemptAutoLogin(isNetworkConnected: Boolean) {
+        if (isNetworkConnected) {
+            fetchIsAccessToken()
+        } else {
+            _authState.value = AuthState.OFFLINE
+        }
     }
 
     private fun fetchIsAccessToken() = viewModelScope.launch {


### PR DESCRIPTION
1. authState에 OFFLINE 상태 추가
2. 네트워크 상태를 ui로 전달
3. viewModel에서 네트워크 미 연결일 때는 api 요청을 하지 않고 authState를 OFFLINE으로 변경, 네트워크가 연결되어 있으면 자동 로그인 요청
4. authState에 따라 로그인 화면으로 이동하거나 홈 화면으로 이동