### PR TITLE
[CHORE] 그룹 카테고리 삭제 팝업 수정 및 그룹원 선택 검색 버튼 추가 (TICO-460)

### DIFF
--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryDeleteOptionDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryDeleteOptionDialog.kt
@@ -23,7 +23,7 @@ import com.tico.pomorodo.ui.common.view.SimpleText
 import com.tico.pomorodo.ui.theme.PomoroDoTheme
 
 @Composable
-fun CategoryOutDialog(
+fun CategoryDeleteOptionDialog(
     title: String,
     content: String,
     onAllDeleteClicked: () -> Unit,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryDeleteOptionDialog.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryDeleteOptionDialog.kt
@@ -27,7 +27,7 @@ fun CategoryDeleteOptionDialog(
     title: String,
     content: String,
     onAllDeleteClicked: () -> Unit,
-    onIncompletedTodoDeleteClicked: () -> Unit,
+    onIncompleteTodoDeleteClicked: () -> Unit,
     onNoDeleteClicked: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -76,7 +76,7 @@ fun CategoryDeleteOptionDialog(
                         contentColor = Color.White,
                         textStyle = PomoroDoTheme.typography.laundryGothicRegular14,
                         verticalPadding = 8.dp,
-                        onClick = onIncompletedTodoDeleteClicked
+                        onClick = onIncompleteTodoDeleteClicked
                     )
                     CustomTextButton(
                         text = stringResource(id = R.string.content_no_delete),

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -158,15 +158,13 @@ fun CategoryInfoScreenRoute(
                 onIncompleteTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
                 onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ }
             )
-            if (generalDeleteDialogVisible) {
-                CategoryDeleteOptionDialog(
-                    title = stringResource(id = R.string.title_category_delete),
-                    content = stringResource(id = R.string.content_category_delete_message),
-                    onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
-                    onIncompleteTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
-                    onNoDeleteClicked = { /*TODO: 일반 카테고리 할 일은 삭제 안하는 로직*/ },
-                    onDismissRequest = { generalDeleteDialogVisible = false })
-            }
+            GeneralDeleteDialog(
+                generalDeleteDialogVisible = generalDeleteDialogVisible,
+                setGeneralDeleteDialogVisible = { generalDeleteDialogVisible = it },
+                onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
+                onIncompleteTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                onNoDeleteClicked = { /*TODO: 일반 카테고리 할 일은 삭제 안하는 로직*/ }
+            )
             if (endOfEditingDialogVisible) {
                 EndOfEditingDialog(
                     onDismissRequest = { endOfEditingDialogVisible = false },
@@ -194,30 +192,6 @@ fun CategoryInfoScreenRoute(
                 onGeneralDeletedClicked = { generalDeleteDialogVisible = true }
             )
         }
-    }
-}
-
-@Composable
-private fun GroupCategoryOutDialog(
-    groupOutDialogVisible: Boolean,
-    category: Category,
-    setGroupOutDialogVisible: (Boolean) -> Unit,
-    onAllDeleteClicked: () -> Unit,
-    onIncompleteTodoDeleteClicked: () -> Unit,
-    onNoDeleteClicked: () -> Unit,
-) {
-    if (groupOutDialogVisible) {
-        CategoryDeleteOptionDialog(
-            title = stringResource(id = R.string.title_group_out),
-            content = stringResource(
-                id = R.string.content_group_out_message,
-                category.title
-            ),
-            onAllDeleteClicked = onAllDeleteClicked,
-            onIncompleteTodoDeleteClicked = onIncompleteTodoDeleteClicked,
-            onNoDeleteClicked = onNoDeleteClicked,
-            onDismissRequest = { setGroupOutDialogVisible(false) }
-        )
     }
 }
 
@@ -455,5 +429,48 @@ private fun GroupCategoryDeleteDialog(
             onValueChange = { deleteDialogInputText = it },
             onConfirmation = onGroupDeleteClicked,
             onDismissRequest = { setGroupDeleteSecondDialogVisible(false) })
+    }
+}
+
+@Composable
+private fun GeneralDeleteDialog(
+    generalDeleteDialogVisible: Boolean,
+    setGeneralDeleteDialogVisible: (Boolean) -> Unit,
+    onAllDeleteClicked: () -> Unit,
+    onIncompleteTodoDeleteClicked: () -> Unit,
+    onNoDeleteClicked: () -> Unit,
+) {
+    if (generalDeleteDialogVisible) {
+        CategoryDeleteOptionDialog(
+            title = stringResource(id = R.string.title_category_delete),
+            content = stringResource(id = R.string.content_category_delete_message),
+            onAllDeleteClicked = onAllDeleteClicked,
+            onIncompleteTodoDeleteClicked = onIncompleteTodoDeleteClicked,
+            onNoDeleteClicked = onNoDeleteClicked,
+            onDismissRequest = { setGeneralDeleteDialogVisible(false) })
+    }
+}
+
+@Composable
+private fun GroupCategoryOutDialog(
+    groupOutDialogVisible: Boolean,
+    category: Category,
+    setGroupOutDialogVisible: (Boolean) -> Unit,
+    onAllDeleteClicked: () -> Unit,
+    onIncompleteTodoDeleteClicked: () -> Unit,
+    onNoDeleteClicked: () -> Unit,
+) {
+    if (groupOutDialogVisible) {
+        CategoryDeleteOptionDialog(
+            title = stringResource(id = R.string.title_group_out),
+            content = stringResource(
+                id = R.string.content_group_out_message,
+                category.title
+            ),
+            onAllDeleteClicked = onAllDeleteClicked,
+            onIncompleteTodoDeleteClicked = onIncompleteTodoDeleteClicked,
+            onNoDeleteClicked = onNoDeleteClicked,
+            onDismissRequest = { setGroupOutDialogVisible(false) }
+        )
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -145,8 +145,21 @@ fun CategoryInfoScreenRoute(
                 )
             }
             if (groupDeleteFirstDialogVisible) {
-                GroupDeleteFirstDialog(
-                    onConfirmation = {
+                CategoryOutDialog(
+                    title = stringResource(id = R.string.title_group_category_delete),
+                    content = stringResource(
+                        id = R.string.content_group_delete_first_message,
+                        category.title
+                    ),
+                    onAllDeleteClicked = {
+                        groupDeleteFirstDialogVisible = false
+                        groupDeleteSecondDialogVisible = true
+                    },
+                    onIncompletedTodoDeleteClicked = {
+                        groupDeleteFirstDialogVisible = false
+                        groupDeleteSecondDialogVisible = true
+                    },
+                    onNoDeleteClicked = {
                         groupDeleteFirstDialogVisible = false
                         groupDeleteSecondDialogVisible = true
                     },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -151,7 +151,7 @@ fun CategoryInfoScreenRoute(
                 onGroupDeleteClicked = { TODO("그룹 카테고리 삭제 로직") }
             )
             if (groupOutDialogVisible) {
-                CategoryOutDialog(
+                CategoryDeleteOptionDialog(
                     title = stringResource(id = R.string.title_group_out),
                     content = stringResource(
                         id = R.string.content_group_out_message,
@@ -164,7 +164,7 @@ fun CategoryInfoScreenRoute(
                 )
             }
             if (generalOutDialogVisible) {
-                CategoryOutDialog(
+                CategoryDeleteOptionDialog(
                     title = stringResource(id = R.string.title_category_delete),
                     content = stringResource(id = R.string.content_category_delete_message),
                     onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
@@ -407,7 +407,7 @@ private fun GroupCategoryDeleteDialog(
     var deleteDialogInputText by rememberSaveable { mutableStateOf("") }
 
     if (groupDeleteFirstDialogVisible) {
-        CategoryOutDialog(
+        CategoryDeleteOptionDialog(
             title = stringResource(id = R.string.title_group_category_delete),
             content = stringResource(
                 id = R.string.content_group_delete_first_message,

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -150,19 +150,14 @@ fun CategoryInfoScreenRoute(
                 setGroupDeleteSecondDialogVisible = { groupDeleteSecondDialogVisible = it },
                 onGroupDeleteClicked = { TODO("그룹 카테고리 삭제 로직") }
             )
-            if (groupOutDialogVisible) {
-                CategoryDeleteOptionDialog(
-                    title = stringResource(id = R.string.title_group_out),
-                    content = stringResource(
-                        id = R.string.content_group_out_message,
-                        category.title
-                    ),
-                    onAllDeleteClicked = { /*TODO: 그룹 카테고리 할 일 모두 삭제 로직*/ },
-                    onIncompletedTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
-                    onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ },
-                    onDismissRequest = { groupOutDialogVisible = false }
-                )
-            }
+            GroupCategoryOutDialog(
+                groupOutDialogVisible = groupOutDialogVisible,
+                category = category,
+                setGroupOutDialogVisible = { groupOutDialogVisible = it },
+                onAllDeleteClicked = { /*TODO: 그룹 카테고리 할 일 모두 삭제 로직*/ },
+                onIncompletedTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ }
+            )
             if (generalOutDialogVisible) {
                 CategoryDeleteOptionDialog(
                     title = stringResource(id = R.string.title_category_delete),
@@ -199,6 +194,30 @@ fun CategoryInfoScreenRoute(
                 onGeneralDeletedClicked = { generalOutDialogVisible = true }
             )
         }
+    }
+}
+
+@Composable
+private fun GroupCategoryOutDialog(
+    groupOutDialogVisible: Boolean,
+    category: Category,
+    setGroupOutDialogVisible: (Boolean) -> Unit,
+    onAllDeleteClicked: () -> Unit,
+    onIncompletedTodoDeleteClicked: () -> Unit,
+    onNoDeleteClicked: () -> Unit,
+) {
+    if (groupOutDialogVisible) {
+        CategoryDeleteOptionDialog(
+            title = stringResource(id = R.string.title_group_out),
+            content = stringResource(
+                id = R.string.content_group_out_message,
+                category.title
+            ),
+            onAllDeleteClicked = onAllDeleteClicked,
+            onIncompletedTodoDeleteClicked = onIncompletedTodoDeleteClicked,
+            onNoDeleteClicked = onNoDeleteClicked,
+            onDismissRequest = { setGroupOutDialogVisible(false) }
+        )
     }
 }
 

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -71,8 +71,6 @@ fun CategoryInfoScreenRoute(
     val categoryState by viewModel.category.collectAsState()
     val selectedGroupMembers by viewModel.selectedGroupMembers.collectAsState()
 
-    var deleteDialogInputText by rememberSaveable { mutableStateOf("") }
-
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -144,37 +142,14 @@ fun CategoryInfoScreenRoute(
                     }
                 )
             }
-            if (groupDeleteFirstDialogVisible) {
-                CategoryOutDialog(
-                    title = stringResource(id = R.string.title_group_category_delete),
-                    content = stringResource(
-                        id = R.string.content_group_delete_first_message,
-                        category.title
-                    ),
-                    onAllDeleteClicked = {
-                        groupDeleteFirstDialogVisible = false
-                        groupDeleteSecondDialogVisible = true
-                    },
-                    onIncompletedTodoDeleteClicked = {
-                        groupDeleteFirstDialogVisible = false
-                        groupDeleteSecondDialogVisible = true
-                    },
-                    onNoDeleteClicked = {
-                        groupDeleteFirstDialogVisible = false
-                        groupDeleteSecondDialogVisible = true
-                    },
-                    onDismissRequest = { groupDeleteFirstDialogVisible = false }
-                )
-            }
-            if (groupDeleteSecondDialogVisible) {
-                GroupDeleteSecondDialog(
-                    groupName = category.title,
-                    enabled = deleteDialogInputText == category.title.getNoSpace(),
-                    value = deleteDialogInputText,
-                    onValueChange = { deleteDialogInputText = it },
-                    onConfirmation = { /*TODO: 그룹 카테고리 삭제 로직*/ },
-                    onDismissRequest = { groupDeleteSecondDialogVisible = false })
-            }
+            GroupCategoryDeleteDialog(
+                groupDeleteFirstDialogVisible = groupDeleteFirstDialogVisible,
+                groupDeleteSecondDialogVisible = groupDeleteSecondDialogVisible,
+                category = category,
+                setGroupDeleteFirstDialogVisible = { groupDeleteFirstDialogVisible = it },
+                setGroupDeleteSecondDialogVisible = { groupDeleteSecondDialogVisible = it },
+                onGroupDeleteClicked = { TODO("그룹 카테고리 삭제 로직") }
+            )
             if (groupOutDialogVisible) {
                 CategoryOutDialog(
                     title = stringResource(id = R.string.title_group_out),
@@ -417,5 +392,49 @@ private fun Category.isReadOnly(isOffline: Boolean): Boolean {
         this.type == CategoryType.GROUP
     } else {
         this.type == CategoryType.GROUP && this.isGroupReader == false
+    }
+}
+
+@Composable
+private fun GroupCategoryDeleteDialog(
+    groupDeleteFirstDialogVisible: Boolean,
+    groupDeleteSecondDialogVisible: Boolean,
+    setGroupDeleteFirstDialogVisible: (Boolean) -> Unit = {},
+    setGroupDeleteSecondDialogVisible: (Boolean) -> Unit = {},
+    category: Category,
+    onGroupDeleteClicked: () -> Unit
+) {
+    var deleteDialogInputText by rememberSaveable { mutableStateOf("") }
+
+    if (groupDeleteFirstDialogVisible) {
+        CategoryOutDialog(
+            title = stringResource(id = R.string.title_group_category_delete),
+            content = stringResource(
+                id = R.string.content_group_delete_first_message,
+                category.title
+            ),
+            onAllDeleteClicked = {
+                setGroupDeleteFirstDialogVisible(false)
+                setGroupDeleteSecondDialogVisible(true)
+            },
+            onIncompletedTodoDeleteClicked = {
+                setGroupDeleteFirstDialogVisible(false)
+                setGroupDeleteSecondDialogVisible(true)
+            },
+            onNoDeleteClicked = {
+                setGroupDeleteFirstDialogVisible(false)
+                setGroupDeleteSecondDialogVisible(true)
+            },
+            onDismissRequest = { setGroupDeleteFirstDialogVisible(false) }
+        )
+    }
+    if (groupDeleteSecondDialogVisible) {
+        GroupDeleteSecondDialog(
+            groupName = category.title,
+            enabled = deleteDialogInputText == category.title.getNoSpace(),
+            value = deleteDialogInputText,
+            onValueChange = { deleteDialogInputText = it },
+            onConfirmation = onGroupDeleteClicked,
+            onDismissRequest = { setGroupDeleteSecondDialogVisible(false) })
     }
 }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -65,7 +65,7 @@ fun CategoryInfoScreenRoute(
     var groupDeleteFirstDialogVisible by rememberSaveable { mutableStateOf(false) }
     var groupDeleteSecondDialogVisible by rememberSaveable { mutableStateOf(false) }
     var groupOutDialogVisible by rememberSaveable { mutableStateOf(false) }
-    var generalOutDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var generalDeleteDialogVisible by rememberSaveable { mutableStateOf(false) }
     var endOfEditingDialogVisible by remember { mutableStateOf(false) }
 
     val categoryState by viewModel.category.collectAsState()
@@ -158,14 +158,14 @@ fun CategoryInfoScreenRoute(
                 onIncompleteTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
                 onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ }
             )
-            if (generalOutDialogVisible) {
+            if (generalDeleteDialogVisible) {
                 CategoryDeleteOptionDialog(
                     title = stringResource(id = R.string.title_category_delete),
                     content = stringResource(id = R.string.content_category_delete_message),
                     onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
                     onIncompleteTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
                     onNoDeleteClicked = { /*TODO: 일반 카테고리 할 일은 삭제 안하는 로직*/ },
-                    onDismissRequest = { generalOutDialogVisible = false })
+                    onDismissRequest = { generalDeleteDialogVisible = false })
             }
             if (endOfEditingDialogVisible) {
                 EndOfEditingDialog(
@@ -191,7 +191,7 @@ fun CategoryInfoScreenRoute(
                 isGroupReader = category.isGroupReader,
                 onGroupDeleteClicked = { groupDeleteFirstDialogVisible = true },
                 onGroupOutClicked = { groupOutDialogVisible = true },
-                onGeneralDeletedClicked = { generalOutDialogVisible = true }
+                onGeneralDeletedClicked = { generalDeleteDialogVisible = true }
             )
         }
     }

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/CategoryInfoScreen.kt
@@ -155,7 +155,7 @@ fun CategoryInfoScreenRoute(
                 category = category,
                 setGroupOutDialogVisible = { groupOutDialogVisible = it },
                 onAllDeleteClicked = { /*TODO: 그룹 카테고리 할 일 모두 삭제 로직*/ },
-                onIncompletedTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                onIncompleteTodoDeleteClicked = { /*TODO: 그룹 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
                 onNoDeleteClicked = { /*TODO: 그룹 카테고리 할 일은 삭제 안하는 로직*/ }
             )
             if (generalOutDialogVisible) {
@@ -163,7 +163,7 @@ fun CategoryInfoScreenRoute(
                     title = stringResource(id = R.string.title_category_delete),
                     content = stringResource(id = R.string.content_category_delete_message),
                     onAllDeleteClicked = { /*TODO: 일반 카테고리 할 일 모두 삭제 로직*/ },
-                    onIncompletedTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
+                    onIncompleteTodoDeleteClicked = { /*TODO: 일반 카테고리 할 일 중 미완료 할 일만 삭제 로직*/ },
                     onNoDeleteClicked = { /*TODO: 일반 카테고리 할 일은 삭제 안하는 로직*/ },
                     onDismissRequest = { generalOutDialogVisible = false })
             }
@@ -203,7 +203,7 @@ private fun GroupCategoryOutDialog(
     category: Category,
     setGroupOutDialogVisible: (Boolean) -> Unit,
     onAllDeleteClicked: () -> Unit,
-    onIncompletedTodoDeleteClicked: () -> Unit,
+    onIncompleteTodoDeleteClicked: () -> Unit,
     onNoDeleteClicked: () -> Unit,
 ) {
     if (groupOutDialogVisible) {
@@ -214,7 +214,7 @@ private fun GroupCategoryOutDialog(
                 category.title
             ),
             onAllDeleteClicked = onAllDeleteClicked,
-            onIncompletedTodoDeleteClicked = onIncompletedTodoDeleteClicked,
+            onIncompleteTodoDeleteClicked = onIncompleteTodoDeleteClicked,
             onNoDeleteClicked = onNoDeleteClicked,
             onDismissRequest = { setGroupOutDialogVisible(false) }
         )
@@ -436,7 +436,7 @@ private fun GroupCategoryDeleteDialog(
                 setGroupDeleteFirstDialogVisible(false)
                 setGroupDeleteSecondDialogVisible(true)
             },
-            onIncompletedTodoDeleteClicked = {
+            onIncompleteTodoDeleteClicked = {
                 setGroupDeleteFirstDialogVisible(false)
                 setGroupDeleteSecondDialogVisible(true)
             },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupMemberChooseScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/category/view/GroupMemberChooseScreen.kt
@@ -55,6 +55,7 @@ import com.tico.pomorodo.ui.iconpack.commonIconPack.IcNoSearch
 import com.tico.pomorodo.ui.theme.IC_ALL_CLEAN
 import com.tico.pomorodo.ui.theme.IC_GROUP_SELECTED_UNCHECKED
 import com.tico.pomorodo.ui.theme.IC_OK
+import com.tico.pomorodo.ui.theme.IC_SEARCH
 import com.tico.pomorodo.ui.theme.IC_SELECTED_GROUP_MEMBER_CANCEL
 import com.tico.pomorodo.ui.theme.IC_UNOK
 import com.tico.pomorodo.ui.theme.IconPack
@@ -147,6 +148,7 @@ private fun GroupMemberChooseScreen(viewModel: ViewModel, navigateToBack: () -> 
                 searchName = searchName,
                 onSearchNameChanged = { searchName = it },
                 filteredList = filteredList,
+                onClickedSearchListener = {}
             )
         }
     }
@@ -158,6 +160,7 @@ fun GroupMemberChooseContent(
     searchName: String,
     onSearchNameChanged: (String) -> Unit,
     filteredList: List<SelectedUser>,
+    onClickedSearchListener: () -> Unit
 ) {
     val textFieldColors = TextFieldDefaults.colors(
         focusedTextColor = PomoroDoTheme.colorScheme.onBackground,
@@ -220,13 +223,26 @@ fun GroupMemberChooseContent(
             ),
             shape = RoundedCornerShape(5.dp),
             trailingIcon = {
-                if (searchName.isNotBlank()) {
+                Row(
+                    modifier = Modifier.padding(end = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(5.dp)
+                ) {
+                    if (searchName.isNotBlank()) {
+                        SimpleIconButton(
+                            size = 34,
+                            imageVector = requireNotNull(PomoroDoTheme.iconPack[IC_ALL_CLEAN]),
+                            contentDescriptionId = R.string.content_ic_all_clean,
+                            enabled = true,
+                            onClickedListener = { onSearchNameChanged("") }
+                        )
+                    }
                     SimpleIconButton(
-                        size = 34,
-                        imageVector = requireNotNull(PomoroDoTheme.iconPack[IC_ALL_CLEAN]),
-                        contentDescriptionId = R.string.content_ic_all_clean,
+                        size = 24,
+                        imageVector = requireNotNull(PomoroDoTheme.iconPack[IC_SEARCH]),
+                        contentDescriptionId = R.string.content_ic_search,
                         enabled = true,
-                        onClickedListener = { onSearchNameChanged("") }
+                        onClickedListener = onClickedSearchListener
                     )
                 }
             },

--- a/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
+++ b/Mobile/PomoroDo/app/src/main/java/com/tico/pomorodo/ui/follow/view/AddFollowerScreen.kt
@@ -83,7 +83,10 @@ fun AddFollowerScreen(
             ),
             shape = RoundedCornerShape(5.dp),
             trailingIcon = {
-                Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                Row(
+                    modifier = Modifier.padding(end = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(5.dp)
+                ) {
                     if (searchName.isNotBlank()) {
                         SimpleIconButton(
                             size = 34,

--- a/Mobile/PomoroDo/app/src/main/res/values/strings.xml
+++ b/Mobile/PomoroDo/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="content_color">색상</string>
     <string name="content_group_out">그룹 나가기</string>
     <string name="title_group_out">그룹 카테고리 나가기</string>
+    <string name="title_group_category_delete">그룹 카테고리 삭제</string>
     <string name="title_group_member_choose">그룹원 선택</string>
     <string name="content_ic_selected_group_member_cancel">그룹원 선택 취소 아이콘</string>
     <string name="content_search_group_member">닉네임 검색</string>
@@ -122,7 +123,7 @@
     <string name="content_group_out_message">\"%s\" 그룹에서 나갑니다.\n기존 할 일을 삭제하시겠습니까?</string>
     <string name="content_group_delete_second_message">삭제하려는 그룹의 이름을 입력하세요.\n“%s”</string>
     <string name="content_group_delete_placehold">그룹 이름을 따라 입력하세요.</string>
-    <string name="content_group_delete_first_message">그룹을 삭제하시겠습니까?\n모든 그룹원들의 할 일이 모두 삭제됩니다.</string>
+    <string name="content_group_delete_first_message">\"%s\" 그룹을 삭제합니다.\n모든 그룹원들의 할 일을 삭제하시겠습니까?</string>
     <string name="content_do_delete">삭제하기</string>
     <string name="title_category_delete">카테고리 삭제</string>
     <string name="content_category_delete_message">카테고리를 삭제합니다.\n기존 할 일을 삭제하시겠습니까?</string>


### PR DESCRIPTION
- 그룹원 선택 페이지에 검색 버튼 추가
- 그룹 카테고리 삭제 팝업 수정
- 카테고리 삭제, 나가기 등 다이얼로그를 categoryInfoScreenRoute에서 분리
 - 같은 다이얼로그를 사용하여 목적이 불분명해 보여서 분리함으로써 코드를 정리하고, 이름으로 목적을 나타 냄