### PR TITLE
[REFACTOR] 카테고리 관련 반환 값 수정 (TICO-283)

### DIFF
--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
@@ -194,21 +194,20 @@ public class CategoryController {
             }
     )
     @PatchMapping("/api/v1/categories/{categoryId}")
-    public ResponseEntity<SuccessResponse<String>> updateCategory(
+    public ResponseEntity<SuccessResponse<CategoryInfoResponse>> updateCategory(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long categoryId,
             @Valid @RequestBody CategoryUpdateRequest request) {
 
-        categoryService.updateCategory(categoryId, userDetails.getUserId(), request);
+        CategoryInfoResponse categoryInfoResponse = categoryService.updateCategory(categoryId, userDetails.getUserId(), request);
 
-        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
+        SuccessResponse<CategoryInfoResponse> successResponse = SuccessResponse.<CategoryInfoResponse>builder()
                 .message(SuccessCode.CATEGORY_UPDATE_SUCCESS.getMessage())
-                .data(SuccessCode.CATEGORY_UPDATE_SUCCESS.name())
+                .data(categoryInfoResponse)
                 .build();
 
         return ResponseEntity.ok(successResponse);
     }
-
 
     /**
      * 카테고리 삭제 API

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryController.java
@@ -4,6 +4,7 @@ import com.tico.pomoro_do.domain.category.dto.request.CategoryCreateRequest;
 import com.tico.pomoro_do.domain.category.dto.request.CategoryDeleteRequest;
 import com.tico.pomoro_do.domain.category.dto.request.CategoryUpdateRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryDetailResponse;
+import com.tico.pomoro_do.domain.category.dto.response.CategoryInfoResponse;
 import com.tico.pomoro_do.domain.category.dto.response.UserCategoryResponse;
 import com.tico.pomoro_do.domain.category.enums.CategoryType;
 import com.tico.pomoro_do.domain.category.service.CategoryService;
@@ -66,15 +67,15 @@ public class CategoryController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping
-    public ResponseEntity<SuccessResponse<Long>> createCategory(
+    public ResponseEntity<SuccessResponse<CategoryInfoResponse>> createCategory(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CategoryCreateRequest request
     ){
-        Long categoryId = categoryService.processCategoryCreation(userDetails.getUserId(), request);
+        CategoryInfoResponse categoryInfoResponse = categoryService.processCategoryCreation(userDetails.getUserId(), request);
 
-        SuccessResponse<Long> successResponse = SuccessResponse.<Long>builder()
+        SuccessResponse<CategoryInfoResponse> successResponse = SuccessResponse.<CategoryInfoResponse>builder()
                 .message(SuccessCode.CATEGORY_CREATION_SUCCESS.getMessage())
-                .data(categoryId)
+                .data(categoryInfoResponse)
                 .build();
 
         return ResponseEntity.status(HttpStatus.CREATED).body(successResponse);

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/controller/CategoryInvitationController.java
@@ -2,6 +2,7 @@ package com.tico.pomoro_do.domain.category.controller;
 
 import com.tico.pomoro_do.domain.category.dto.request.CategoryInvitationDecisionRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryInvitationResponse;
+import com.tico.pomoro_do.domain.category.dto.response.InvitedCategoryInfoResponse;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
 import com.tico.pomoro_do.domain.category.service.CategoryInvitationService;
 import com.tico.pomoro_do.global.response.SuccessCode;
@@ -100,16 +101,16 @@ public class CategoryInvitationController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PatchMapping("/{invitationId}")
-    public ResponseEntity<SuccessResponse<String>> responseInvitation(
+    public ResponseEntity<SuccessResponse<InvitedCategoryInfoResponse>> responseInvitation(
             @PathVariable Long invitationId,
             @RequestBody CategoryInvitationDecisionRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails // 로그인 유저
     ) {
-        categoryInvitationService.respondInvitation(invitationId, userDetails.getUserId(), request);
+        InvitedCategoryInfoResponse invitedCategoryInfoResponse = categoryInvitationService.respondInvitation(invitationId, userDetails.getUserId(), request);
 
-        SuccessResponse<String> successResponse = SuccessResponse.<String>builder()
+        SuccessResponse<InvitedCategoryInfoResponse> successResponse = SuccessResponse.<InvitedCategoryInfoResponse>builder()
                 .message(SuccessCode.CATEGORY_INVITATION_RESPONSE_SUCCESS.getMessage())
-                .data(SuccessCode.CATEGORY_INVITATION_RESPONSE_SUCCESS.name())
+                .data(invitedCategoryInfoResponse)
                 .build();
         return ResponseEntity.ok(successResponse);
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/CategoryInfoResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/CategoryInfoResponse.java
@@ -1,0 +1,24 @@
+package com.tico.pomoro_do.domain.category.dto.response;
+
+import com.tico.pomoro_do.domain.category.entity.Category;
+import com.tico.pomoro_do.domain.category.enums.CategoryType;
+import com.tico.pomoro_do.domain.category.enums.CategoryVisibility;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryInfoResponse {
+    private final Long categoryId;
+    private final String name;
+    private final CategoryType type;
+    private final CategoryVisibility visibility;
+    private final int totalMembers;
+
+    public static CategoryInfoResponse of(Category c, int totalMembers) {
+        return new CategoryInfoResponse(
+                c.getId(), c.getName(), c.getType(), c.getVisibility(), totalMembers
+        );
+    }
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/CategoryMemberResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/CategoryMemberResponse.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 @Getter
 public class CategoryMemberResponse {
 
-    private final Long groupMemberId; // 그룹멤버 ID
+    private final Long userId; // 그룹멤버의 User ID
     private final String nickname; // 사용자 이름
     private final String profileImageUrl; // 프로필 이미지 URL
 
     @Builder
-    public CategoryMemberResponse(Long groupMemberId, String nickname, String profileImageUrl) {
-        this.groupMemberId = groupMemberId;
+    public CategoryMemberResponse(Long userId, String nickname, String profileImageUrl) {
+        this.userId = userId;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/InvitedCategoryInfoResponse.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/dto/response/InvitedCategoryInfoResponse.java
@@ -1,0 +1,23 @@
+package com.tico.pomoro_do.domain.category.dto.response;
+
+import com.tico.pomoro_do.domain.category.entity.Category;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InvitedCategoryInfoResponse {
+
+    private final Long categoryId;
+    private final String name;
+    private final int totalMembers;
+
+    public static InvitedCategoryInfoResponse of(Category category, int totalMembers) {
+        return new InvitedCategoryInfoResponse(
+                category.getId(),
+                category.getName(),
+                totalMembers
+        );
+    }
+}

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/repository/CategoryMemberRepository.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/repository/CategoryMemberRepository.java
@@ -22,6 +22,9 @@ public interface CategoryMemberRepository extends JpaRepository<CategoryMember, 
     // 해당 카테고리의 활성화 되어있는 멤버들 조회 (category=category, leftDate=null)
     List<CategoryMember> findAllByCategoryAndLeftDateIsNull(Category category);
 
+    // 활동 중(탈퇴하지 않은) 멤버 수
+    int countByCategoryIdAndLeftDateIsNull(Long categoryId);
+
     /**
      * 카테고리와 사용자로 멤버십 존재 여부 확인 (탈퇴 여부도 확인)
      *

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationService.java
@@ -2,6 +2,7 @@ package com.tico.pomoro_do.domain.category.service;
 
 import com.tico.pomoro_do.domain.category.dto.request.CategoryInvitationDecisionRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryInvitationResponse;
+import com.tico.pomoro_do.domain.category.dto.response.InvitedCategoryInfoResponse;
 import com.tico.pomoro_do.domain.category.entity.Category;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
 import com.tico.pomoro_do.domain.user.entity.User;
@@ -66,7 +67,7 @@ public interface CategoryInvitationService {
      * @param userId 응답하는 사용자 ID
      * @param request 응답 요청 객체 (ACCEPTED 또는 REJECTED)
      */
-    void respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request);
+    InvitedCategoryInfoResponse respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request);
 
     /**
      * 해당 카테고리에 대한 응답되지 않은(PENDING) 초대장 모두 삭제

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryInvitationServiceImpl.java
@@ -2,6 +2,7 @@ package com.tico.pomoro_do.domain.category.service;
 
 import com.tico.pomoro_do.domain.category.dto.request.CategoryInvitationDecisionRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryInvitationResponse;
+import com.tico.pomoro_do.domain.category.dto.response.InvitedCategoryInfoResponse;
 import com.tico.pomoro_do.domain.category.entity.Category;
 import com.tico.pomoro_do.domain.category.entity.CategoryInvitation;
 import com.tico.pomoro_do.domain.category.enums.CategoryInvitationStatus;
@@ -225,7 +226,7 @@ public class CategoryInvitationServiceImpl implements CategoryInvitationService{
      */
     @Override
     @Transactional
-    public void respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request) {
+    public InvitedCategoryInfoResponse respondInvitation(Long invitationId, Long userId, CategoryInvitationDecisionRequest request) {
         // 1. 초대장 조회
         CategoryInvitation invitation = getInvitationById(invitationId);
         // 2. 초대 대상자 본인인지 확인
@@ -250,6 +251,11 @@ public class CategoryInvitationServiceImpl implements CategoryInvitationService{
             log.info("초대 수락: 그룹 멤버 생성 완료 - categoryId={}, userId={}",
                     invitation.getCategory().getId(), invitation.getInvitee().getId());
         }
+
+        // 6. 현재 활성 멤버 수 계산
+        int totalMembers = categoryMemberService.countActiveMembers(invitation.getCategory().getId());
+
+        return InvitedCategoryInfoResponse.of(invitation.getCategory(), totalMembers);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberService.java
@@ -42,6 +42,11 @@ public interface CategoryMemberService {
     Map<Long, Long> getActiveMemberCounts(List<Category> groupCategories);
 
     /**
+     * 활동 중(LEFT_DATE IS NULL) 멤버 수를 반환
+     */
+    int countActiveMembers(Long categoryId);
+
+    /**
      * 그룹 카테고리의 활동 중인 멤버 목록을 닉네임 기준으로 정렬된 응답 DTO 반환
      *
      * @param category 그룹 카테고리

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberServiceImpl.java
@@ -153,6 +153,18 @@ public class CategoryMemberServiceImpl implements CategoryMemberService {
     }
 
     /**
+     * 해당 그룹 카테고리에 대해 현재 참여 중인 멤버 수 조회
+     *
+     * @param categoryId 대상 그룹 카테고리 ID
+     * @return 그룹 멤버 수
+     */
+    @Override
+    public int countActiveMembers(Long categoryId) {
+        // 필요 시 categoryId 유효성 검증/권한 체크 추가 가능
+        return categoryMemberRepository.countByCategoryIdAndLeftDateIsNull(categoryId);
+    }
+
+    /**
      * 여러 그룹 카테고리에 대해 현재 참여 중인 멤버 수 조회
      *
      * @param groupCategories 대상 그룹 카테고리 목록

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryMemberServiceImpl.java
@@ -182,7 +182,7 @@ public class CategoryMemberServiceImpl implements CategoryMemberService {
 
         return categoryMembers.stream()
                 .map(member -> CategoryMemberResponse.builder()
-                        .groupMemberId(member.getId())
+                        .userId(member.getUser().getId())
                         .nickname(member.getUser().getNickname())
                         .profileImageUrl(member.getUser().getProfileImageUrl())
                         .build())

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.tico.pomoro_do.domain.category.dto.request.CategoryCreateRequest;
 import com.tico.pomoro_do.domain.category.dto.request.CategoryDeleteRequest;
 import com.tico.pomoro_do.domain.category.dto.request.CategoryUpdateRequest;
 import com.tico.pomoro_do.domain.category.dto.response.CategoryDetailResponse;
+import com.tico.pomoro_do.domain.category.dto.response.CategoryInfoResponse;
 import com.tico.pomoro_do.domain.category.dto.response.UserCategoryResponse;
 import com.tico.pomoro_do.domain.category.entity.Category;
 import com.tico.pomoro_do.domain.category.enums.CategoryType;
@@ -21,7 +22,7 @@ public interface CategoryService {
      * @param request 카테고리 생성 요청 DTO
      * @return 생성된 카테고리의 ID
      */
-    Long processCategoryCreation(Long userId, CategoryCreateRequest request);
+    CategoryInfoResponse processCategoryCreation(Long userId, CategoryCreateRequest request);
 
     /**
      * 새로운 카테고리 객체를 생성하고 저장

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryService.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryService.java
@@ -59,9 +59,9 @@ public interface CategoryService {
      *
      * @param userId 수정 요청 사용자 ID
      * @param categoryId 수정 대상 카테고리 ID
-     * @param request 수정 정보 (카테고리 이름, CategoryVisibility)
+     * @param request 수정 정보 (카테고리 이름, CategoryVisibility, ...)
      */
-    void updateCategory(Long categoryId, Long userId, CategoryUpdateRequest request);
+    CategoryInfoResponse updateCategory(Long categoryId, Long userId, CategoryUpdateRequest request);
 
     /**
      * 카테고리 삭제

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
@@ -41,7 +41,7 @@ public class CategoryServiceImpl implements CategoryService {
      */
     @Override
     @Transactional
-    public Long processCategoryCreation(Long userId, CategoryCreateRequest request) {
+    public CategoryInfoResponse processCategoryCreation(Long userId, CategoryCreateRequest request) {
         // 1. 사용자 조회
         User owner = userService.findUserById(userId);
 
@@ -59,7 +59,7 @@ public class CategoryServiceImpl implements CategoryService {
         log.info("카테고리 생성 완료: categoryId={}, 유형={}, 이름={}, 소유자={}",
                 category.getId(), category.getType(), category.getName(), owner.getId());
 
-        return category.getId();
+        return CategoryInfoResponse.of(category, 1);
     }
 
     /**

--- a/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
+++ b/backend/pomoro-do/src/main/java/com/tico/pomoro_do/domain/category/service/CategoryServiceImpl.java
@@ -276,7 +276,7 @@ public class CategoryServiceImpl implements CategoryService {
      */
     @Transactional
     @Override
-    public void updateCategory(Long categoryId, Long userId, CategoryUpdateRequest request) {
+    public CategoryInfoResponse updateCategory(Long categoryId, Long userId, CategoryUpdateRequest request) {
         // 1. 카테고리 조회
         Category category = categoryValidator.validateExists(categoryId);
 
@@ -303,6 +303,12 @@ public class CategoryServiceImpl implements CategoryService {
         } else {
             category.update(request.getName(), request.getVisibility());
         }
+
+        int totalMembers = (category.getType() == CategoryType.GROUP)
+                ? categoryMemberService.countActiveMembers(category.getId())
+                : 1;
+
+        return CategoryInfoResponse.of(category, totalMembers);
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [X] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Related to: TICO-283

## 📝 개요
- 카테고리 생성, 수정, 초대 응답 API의 반환값 구조를 개선했습니다.
- 기존 단순 메시지 또는 ID 반환에서, 카테고리 정보를 포함하는 응답 객체로 변경했습니다.

## 🔁 변경 사항
- 카테고리 생성 시 CategoryInfoResponse 반환
- 카테고리 수정 시 CategoryInfoResponse 반환
- 카테고리 초대 응답 시 InvitedCategoryInfoResponse 반환

## 👀 참고 사항
- 카테고리 수정/ 생성과 초대응답이 다르니 응답 구조를 확인해주세요.

## 👀 기타